### PR TITLE
Fix missing pip requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,7 @@ resize-right
 rich
 safetensors
 scikit-image
+shared
 timm
 toml
 torch


### PR DESCRIPTION
61032b8d9bdf45eb2a085df6149c29fc69481467 added dependency to `shared` in `modules/prompt_parser.py`, but this library is not listed in `requirements.txt`. Running webui throws `ModuleNotFoundError`.

This PR adds `shared` to `requirements.txt`.