### PR TITLE
🔃❌ buttons in extra networks submenu

### DIFF
--- a/javascript/extraNetworks.js
+++ b/javascript/extraNetworks.js
@@ -5,10 +5,12 @@ function setupExtraNetworksForTab(tabname){
     var tabs = gradioApp().querySelector('#'+tabname+'_extra_tabs > div')
     var search = gradioApp().querySelector('#'+tabname+'_extra_search textarea')
     var refresh = gradioApp().getElementById(tabname+'_extra_refresh')
+    var close = gradioApp().getElementById(tabname+'_extra_close')
 
     search.classList.add('search')
     tabs.appendChild(search)
     tabs.appendChild(refresh)
+    tabs.appendChild(close)
 
     search.addEventListener("input", function(evt){
         searchTerm = search.value.toLowerCase()

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -10,6 +10,7 @@ import gradio as gr
 from modules import shared
 from modules.images import read_info_from_image
 from modules.generation_parameters_copypaste import image_from_url_text
+from modules.ui_components import ToolButton
 
 extra_pages = []
 allowed_dirs = set()
@@ -248,8 +249,8 @@ def create_ui(container, button, tabname):
                 ui.pages.append(page_elem)
 
     filter = gr.Textbox('', show_label=False, elem_id=tabname+"_extra_search", placeholder="Search...", visible=False)
-    button_refresh = gr.Button(refresh_symbol, elem_id=tabname+"_extra_refresh")
-    button_close = gr.Button(close_symbol, elem_id=tabname+"_extra_close")
+    button_refresh = ToolButton(refresh_symbol, elem_id=tabname+"_extra_refresh")
+    button_close = ToolButton(close_symbol, elem_id=tabname+"_extra_close")
 
     ui.button_save_preview = gr.Button('Save preview', elem_id=tabname+"_save_preview", visible=False)
     ui.preview_target_filename = gr.Textbox('Preview save filename', elem_id=tabname+"_preview_filename", visible=False)

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -14,6 +14,8 @@ from modules.generation_parameters_copypaste import image_from_url_text
 extra_pages = []
 allowed_dirs = set()
 
+refresh_symbol = '\U0001f504'  # 🔄
+close_symbol = '\U0000274C'  # ❌
 
 def register_page(page):
     """registers extra networks page for the UI; recommend doing it in on_before_ui() callback for extensions"""
@@ -246,7 +248,8 @@ def create_ui(container, button, tabname):
                 ui.pages.append(page_elem)
 
     filter = gr.Textbox('', show_label=False, elem_id=tabname+"_extra_search", placeholder="Search...", visible=False)
-    button_refresh = gr.Button('Refresh', elem_id=tabname+"_extra_refresh")
+    button_refresh = gr.Button(refresh_symbol, elem_id=tabname+"_extra_refresh")
+    button_close = gr.Button(close_symbol, elem_id=tabname+"_extra_close")
 
     ui.button_save_preview = gr.Button('Save preview', elem_id=tabname+"_save_preview", visible=False)
     ui.preview_target_filename = gr.Textbox('Preview save filename', elem_id=tabname+"_preview_filename", visible=False)
@@ -257,6 +260,7 @@ def create_ui(container, button, tabname):
 
     state_visible = gr.State(value=False)
     button.click(fn=toggle_visibility, inputs=[state_visible], outputs=[state_visible, container, button])
+    button_close.click(fn=toggle_visibility, inputs=[state_visible], outputs=[state_visible, container])
 
     def refresh():
         res = []


### PR DESCRIPTION
## Description

5 weeks ago a PR was merged on stable-diffusion-webui removing the Close button from the Extra Networks submenu, under the logic that it saves space as the 🎴 button up above also closes the menu. This is slightly cumbersome for some people as you may need to scroll up, and the 🎴 button is part of a row of otherwise single-purpose buttons.

An alternative solution was to use the 🔁 emoji for UI consistency instead of the word "Refresh", and ❌ instead of "Close" to match. This uses the same space as the "Refresh" button currently does and it is my opinion that it is the superior stylistic choice.

See: https://github.com/vladmandic/automatic/discussions/307

## Notes

Relevant commits and discussion can be found here: https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/7965

Additionally, I replaced the normal buttons with the smaller "tool" buttons which all other emoji buttons use.


## Examples

As it appears on Chrome with black-orange theme:

![image](https://user-images.githubusercontent.com/33796679/233459699-79bf308d-e0a8-45e7-ab75-047d0cdd769d.png)

As it appears on Firefox with default theme:

![image](https://user-images.githubusercontent.com/33796679/233459153-7a7a625c-39a1-46aa-b023-a977632dddca.png)

As it appears on Android (Firefox) with default theme:

![image](https://user-images.githubusercontent.com/33796679/233460548-1f196c6d-2ce7-4abb-84c4-20ce76e7368b.png)

## Environment and Testing

Windows 10, Firefox + Chrome
