### PR TITLE
Fix #291 -  No module named 'rich'

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -7,10 +7,8 @@ import setup
 import modules.paths_internal
 from modules import cmd_args
 
-try:
-    from rich import print # pylint: disable=redefined-builtin
-except ImportError:
-    pass
+setup.ensure_base_requirements()
+from rich import print # pylint: disable=redefined-builtin
 
 ### majority of this file is superflous, but used by some extensions as helpers during extension installation
 

--- a/setup.py
+++ b/setup.py
@@ -34,27 +34,21 @@ def setup_logging(clean=False):
     except:
         pass
     logging.basicConfig(level=logging.DEBUG, format='%(asctime)s | %(levelname)s | %(pathname)s | %(message)s', filename='setup.log', filemode='a', encoding='utf-8', force=True)
-    try: # we may not have rich on the first run
-        from rich.theme import Theme
-        from rich.logging import RichHandler
-        from rich.console import Console
-        from rich.pretty import install as pretty_install
-        from rich.traceback import install as traceback_install
-        console = Console(log_time=True, log_time_format='%H:%M:%S-%f', theme=Theme({
-            "traceback.border": "black",
-            "traceback.border.syntax_error": "black",
-            "inspect.value.border": "black",
-        }))
-        pretty_install(console=console)
-        traceback_install(console=console, extra_lines=1, width=console.width, word_wrap=False, indent_guides=False, suppress=[])
-        rh = RichHandler(show_time=True, omit_repeated_times=False, show_level=True, show_path=False, markup=False, rich_tracebacks=True, log_time_format='%H:%M:%S-%f', level=logging.DEBUG if args.debug else logging.INFO, console=console)
-        rh.set_name(logging.DEBUG if args.debug else logging.INFO)
-        log.addHandler(rh)
-    except:
-        sh = logging.StreamHandler()
-        sh.setLevel(logging.DEBUG if args.debug else logging.INFO)
-        log.addHandler(sh)
-
+    from rich.theme import Theme
+    from rich.logging import RichHandler
+    from rich.console import Console
+    from rich.pretty import install as pretty_install
+    from rich.traceback import install as traceback_install
+    console = Console(log_time=True, log_time_format='%H:%M:%S-%f', theme=Theme({
+        "traceback.border": "black",
+        "traceback.border.syntax_error": "black",
+        "inspect.value.border": "black",
+    }))
+    pretty_install(console=console)
+    traceback_install(console=console, extra_lines=1, width=console.width, word_wrap=False, indent_guides=False, suppress=[])
+    rh = RichHandler(show_time=True, omit_repeated_times=False, show_level=True, show_path=False, markup=False, rich_tracebacks=True, log_time_format='%H:%M:%S-%f', level=logging.DEBUG if args.debug else logging.INFO, console=console)
+    rh.set_name(logging.DEBUG if args.debug else logging.INFO)
+    log.addHandler(rh)
 
 # check if package is installed
 def installed(package, friendly: str = None):
@@ -312,7 +306,17 @@ def install_submodules():
                 log.error(f'Error updating submodule: {submodule}')
 
 
-# install requirements
+def ensure_package(package):
+    try:
+        import package
+    except ImportError:
+        install(package)
+
+
+def ensure_base_requirements():
+    ensure_package('rich')
+
+
 def install_requirements():
     if args.skip_requirements:
         return


### PR DESCRIPTION
## Description

This solves a bug where `rich` is being loaded despite it not being installed.

## Notes

I already tried to do some debugging earlier as per https://github.com/vladmandic/automatic/issues/291#issuecomment-1517413746, but while I was looking into fixing it, I quickly discovered that the `parse_args` method is also being called here, even earlier:

https://github.com/vladmandic/automatic/blob/2ddbb6670484ed31120dc7bcdef4c292400e7a27/launch.py#L15-L20

As such, this fix ensures rich is installed right before that, which also removes the need to try-catch it further on during the first run (as now we can be certain it's there).

## Environment and Testing

Verified this to work after the changes were made by creating a fresh clone of this fork/these changes and running `webui.bat` again.

- Windows 11 x64
- Python 3.10.11
- Nvidia 3060 TI

---

Closes #291