### PR TITLE
Fix problems when --data-dir is specified

### DIFF
--- a/modules/paths_internal.py
+++ b/modules/paths_internal.py
@@ -16,6 +16,6 @@ parser_pre.add_argument("--models-dir", type=str, default="models", help="base p
 cmd_opts_pre = parser_pre.parse_known_args()[0]
 data_path = cmd_opts_pre.data_dir
 
-models_path = os.path.join(cmd_opts_pre.models_dir)
+models_path = os.path.join(data_path, cmd_opts_pre.models_dir)
 extensions_dir = os.path.join(data_path, "extensions")
-extensions_builtin_dir = os.path.join(data_path, "extensions-builtin")
+extensions_builtin_dir = os.path.join(script_path, "extensions-builtin")

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1724,7 +1724,7 @@ def html_css():
             continue
         head += stylesheet(cssfile)
     if opts.gradio_theme == 'black-orange':
-        head += stylesheet(os.path.join(data_path, "javascript", "black-orange.css"))
+        head += stylesheet(os.path.join(script_path, "javascript", "black-orange.css"))
     if os.path.exists(os.path.join(data_path, "user.css")):
         head += stylesheet(os.path.join(data_path, "user.css"))
     return head

--- a/setup.py
+++ b/setup.py
@@ -278,18 +278,20 @@ def list_extensions(folder):
 
 # run installer for each installed and enabled extension and optionally update them
 def install_extensions():
-    for folder in ['extensions-builtin', 'extensions']:
-        extensions_dir = os.path.join(os.path.dirname(__file__), folder)
-        extensions = list_extensions(extensions_dir)
+    from modules.paths_internal import extensions_builtin_dir, extensions_dir
+    for folder in [extensions_builtin_dir, extensions_dir]:
+        if not os.path.isdir(folder):
+            continue
+        extensions = list_extensions(folder)
         log.info(f'Extensions enabled: {extensions}')
         for ext in extensions:
             if not args.noupdate:
                 try:
-                    update(os.path.join(extensions_dir, ext))
+                    update(os.path.join(folder, ext))
                 except:
-                    log.error(f'Error updating extension: {os.path.join(extensions_dir, ext)}')
+                    log.error(f'Error updating extension: {os.path.join(folder, ext)}')
             if not args.skip_extensions:
-                run_extension_installer(os.path.join(extensions_dir, ext))
+                run_extension_installer(os.path.join(folder, ext))
 
 
 # initialize and optionally update submodules
@@ -358,12 +360,14 @@ def set_environment():
 
 def check_extensions():
     newest_all = os.path.getmtime('requirements.txt')
-    for folder in ['extensions-builtin', 'extensions']:
-        extensions_dir = os.path.join(os.path.dirname(__file__), folder)
-        extensions = list_extensions(extensions_dir)
+    from modules.paths_internal import extensions_builtin_dir, extensions_dir
+    for folder in [extensions_builtin_dir, extensions_dir]:
+        if not os.path.isdir(folder):
+            continue
+        extensions = list_extensions(folder)
         for ext in extensions:
             newest = 0
-            extension_dir = os.path.join(extensions_dir, ext)
+            extension_dir = os.path.join(folder, ext)
             for f in os.listdir(extension_dir):
                 if '.json' in f or '.csv' in f:
                     continue
@@ -459,8 +463,9 @@ def parse_args():
     parser.add_argument('--skip-git', default = False, action='store_true', help = "Skips running all GIT operations, default: %(default)s")
     log.info('Running extension preloading')
     from modules.script_loading import preload_extensions
-    preload_extensions('extensions', parser)
-    preload_extensions('extensions-builtin', parser)
+    from modules.paths_internal import extensions_builtin_dir, extensions_dir
+    preload_extensions(extensions_dir, parser)
+    preload_extensions(extensions_builtin_dir, parser)
 
     global args # pylint: disable=global-statement
     args = parser.parse_args()


### PR DESCRIPTION
## Description

Fix the following problems that occur when --data-dir is specified.

* The program terminates abnormally because black-orange.css is not found.
* No models under data-dir are recognized.
* No builtin extensions appear in the webui.
* The install.py in external extensions are not executed.

## Notes

* modules/paths_internal.py
    * `models_path` should be relative path from data-dir. If `models_path` is an absolute path, data-dir is ignored.
    * `extensions_builtin_dir` should not use data-dir because it does not move from the script directory.
* modules/ui.py
    * `javascript/black-orange.css` should not use data-dir because it does not move from the script directory.
* setup.py
    * `extensions` directory should be relative path from data-dir.

## Environment and Testing

Ubuntu 22.04/WSL2 on Windows 10