### PR TITLE
Fix multiple notifications on refresh

### DIFF
--- a/javascript/notification.js
+++ b/javascript/notification.js
@@ -2,7 +2,9 @@
 
 let lastHeadImg = null;
 
-notificationButton = null
+let notificationButton = null;
+
+const regExpTempImage = /.*tmp.*.png/g;
 
 onUiUpdate(function(){
     if(notificationButton == null){
@@ -22,6 +24,8 @@ onUiUpdate(function(){
     const headImg = galleryPreviews[0]?.src;
 
     if (headImg == null || headImg == lastHeadImg) return;
+
+    if (headImg.search(regExpTempImage) != -1) return;
 
     lastHeadImg = headImg;
 

--- a/javascript/notification.js
+++ b/javascript/notification.js
@@ -4,7 +4,7 @@ let lastHeadImg = null;
 
 let notificationButton = null;
 
-const regExpTempImage = /.*tmp.*.png/g;
+const regExpTempImage = /\/tmp.*\.png$/g;
 
 onUiUpdate(function(){
     if(notificationButton == null){

--- a/javascript/notification.js
+++ b/javascript/notification.js
@@ -4,7 +4,7 @@ let lastHeadImg = null;
 
 let notificationButton = null;
 
-const regExpTempImage = /\/tmp.*\.png$/g;
+const regExpTempImage = /(?<=\/|\\)tmp[\w\d]{8}\.png$/gm;
 
 onUiUpdate(function(){
     if(notificationButton == null){


### PR DESCRIPTION
## Description

When opening or refreshing the webUI, multiple notifications are triggered from the default image. This commit adds a check to notifications.js to see if the head image's filename contains "tmp*.png", which indicates that it is a default image. It suppresses notifications on this match.

## Notes

This is a very basic regexp match. It could possibly trigger and prevent regular notifications if someone has "tmp" at the beginning of their generated images for some reason. That would be an odd use case though, so in theory it shouldn't cause an issue.

I also corrected what looked like a typo on line 5, where notificationButton was set but not initialized. This did not cause any issues in my testing.

## Environment and Testing

Version: https://github.com/vladmandic/automatic/commit/bb438efed47d5ed064ea5933cccc009d8549d4cb
OS: Windows 11
Browser: Firefox 112.0.1 (64-bit)
