### PR TITLE
sd_vae automatic behaviour fix for non-Windows users

### DIFF
--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -107,9 +107,6 @@ def resolve_vae(checkpoint_file):
             if os.path.isfile(named_vae_location):
                 print(named_vae_location+' found in VAE dir')
                 return named_vae_location, ' found in VAE dir'
-            else:
-                print(f"Couldn't find a VAE with a matching name in {vae_path}, using None instead")
-                return None, None
 
     if shared.opts.sd_vae == "None":
         return None, None
@@ -120,6 +117,8 @@ def resolve_vae(checkpoint_file):
 
     if not is_automatic:
         print(f"Couldn't find VAE named {shared.opts.sd_vae}; using None instead")
+        
+    print(f"No matching VAE found, using None instead")    
 
     return None, None
 

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -103,7 +103,7 @@ def resolve_vae(checkpoint_file):
         return vae_near_checkpoint, 'found near the checkpoint'
     
     if is_automatic:
-        for named_vae_location in [vae_path + "\\" + Path(checkpoint_file).stem + ".vae.pt", vae_path + "\\" + Path(checkpoint_file).stem + ".vae.ckpt", vae_path + "\\" + Path(checkpoint_file).stem + ".vae.safetensors"]:
+        for named_vae_location in [vae_path + os.sep + Path(checkpoint_file).stem + ".vae.pt", vae_path + os.sep + Path(checkpoint_file).stem + ".vae.ckpt", vae_path + os.sep + Path(checkpoint_file).stem + ".vae.safetensors"]:
             if os.path.isfile(named_vae_location):
                 print(named_vae_location+' found in VAE dir')
                 return named_vae_location, ' found in VAE dir'

--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -5,7 +5,6 @@ from copy import deepcopy
 from rich import print # pylint: disable=redefined-builtin
 import torch
 from modules import paths, shared, devices, script_callbacks, sd_models
-from pathlib import Path
 
 
 vae_ignore_keys = {"model_ema.decay", "model_ema.num_updates"}
@@ -103,7 +102,7 @@ def resolve_vae(checkpoint_file):
         return vae_near_checkpoint, 'found near the checkpoint'
     
     if is_automatic:
-        for named_vae_location in [vae_path + os.sep + Path(checkpoint_file).stem + ".vae.pt", vae_path + os.sep + Path(checkpoint_file).stem + ".vae.ckpt", vae_path + os.sep + Path(checkpoint_file).stem + ".vae.safetensors"]:
+        for named_vae_location in [os.path.join(vae_path, os.path.splitext(os.path.basename(checkpoint_file))[0] + ".vae.pt"), os.path.join(vae_path, os.path.splitext(os.path.basename(checkpoint_file))[0] + ".vae.ckpt"), os.path.join(vae_path, os.path.splitext(os.path.basename(checkpoint_file))[0] + ".vae.safetensors")]:
             if os.path.isfile(named_vae_location):
                 print(named_vae_location+' found in VAE dir')
                 return named_vae_location, ' found in VAE dir'


### PR DESCRIPTION
Hadn't considered that hard-coding the separators would break this for non-Windows users - replaced hard coding with os.sep