### PR TITLE
unipc latent upscale

### DIFF
--- a/modules/models/diffusion/uni_pc/sampler.py
+++ b/modules/models/diffusion/uni_pc/sampler.py
@@ -47,8 +47,6 @@ class UniPCSampler(object):
                 shared.opts.uni_pc_order+1,
             )
 
-        t = torch.full(t.shape, self.steps).to(t.device)
-
         scheduler_timesteps = np.linspace(
                 0,
                 self.model.num_timesteps-1,
@@ -62,13 +60,17 @@ class UniPCSampler(object):
         latent_timestep = sample_timesteps[:1].repeat(x0.shape[0])
 
         alphas_cumprod = self.alphas_cumprod
-        sqrt_alphas_prod = alphas_cumprod[latent_timestep] ** 0.5
-        sqrt_alphas_prod = sqrt_alphas_prod.flatten()
+        sqrt_alpha_prod = alphas_cumprod[latent_timestep] ** 0.5
+        sqrt_alpha_prod = sqrt_alpha_prod.flatten()
+        while len(sqrt_alpha_prod.shape) < len(x0.shape):
+            sqrt_alpha_prod = sqrt_alpha_prod.unsqueeze(-1)
 
         sqrt_one_minus_alpha_prod = (1 - alphas_cumprod[latent_timestep]) ** 0.5
         sqrt_one_minus_alpha_prod = sqrt_one_minus_alpha_prod.flatten()
+        while len(sqrt_one_minus_alpha_prod.shape) < len(x0.shape):
+            sqrt_one_minus_alpha_prod = sqrt_one_minus_alpha_prod.unsqueeze(-1)
 
-        return (sqrt_alphas_prod * x0 + sqrt_one_minus_alpha_prod * noise)
+        return (sqrt_alpha_prod * x0 + sqrt_one_minus_alpha_prod * noise)
 
     def decode(self, x_latent, conditioning, t_start, unconditional_guidance_scale=1.0, unconditional_conditioning=None,
                use_original_steps=False, callback=None):

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -970,9 +970,10 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
         shared.state.nextjob()
 
         img2img_sampler_name = self.sampler_name
-        if self.sampler_name in ['PLMS']:
+        force_latent_upscaler = shared.opts.data.get('xyz_fallback_sampler')
+        if self.sampler_name in ['PLMS'] or force_latent_upscaler is not None:
             # PLMS does not support img2img, use fallback instead
-            img2img_sampler_name = shared.opts.fallback_sampler
+            img2img_sampler_name = force_latent_upscaler or shared.opts.fallback_sampler
         self.sampler = sd_samplers.create_sampler(img2img_sampler_name, self.sd_model)
 
         samples = samples[:, :, self.truncate_y//2:samples.shape[2]-(self.truncate_y+1)//2, self.truncate_x//2:samples.shape[3]-(self.truncate_x+1)//2]

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -970,7 +970,8 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
         shared.state.nextjob()
 
         img2img_sampler_name = self.sampler_name
-        if self.sampler_name in ['PLMS', 'UniPC']:  # PLMS/UniPC do not support img2img so we just silently switch to DDIM
+        if self.sampler_name in ['PLMS']:
+            # PLMS does not support img2img, use fallback instead
             img2img_sampler_name = shared.opts.fallback_sampler
         self.sampler = sd_samplers.create_sampler(img2img_sampler_name, self.sd_model)
 

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -128,6 +128,14 @@ def apply_styles(p: StableDiffusionProcessingTxt2Img, x: str, _):
     p.styles.extend(x.split(','))
 
 
+def apply_fallback(p, x, xs):
+    sampler_name = sd_samplers.samplers_map.get(x.lower(), None)
+    if sampler_name is None:
+        raise RuntimeError(f"Unknown sampler: {x}")
+
+    opts.data["xyz_fallback_sampler"] = sampler_name
+
+
 def apply_uni_pc_order(p, x, xs):
     opts.data["uni_pc_order"] = min(x, p.steps - 1)
 
@@ -220,6 +228,7 @@ axis_options = [
     AxisOption("Clip skip", int, apply_clip_skip),
     AxisOption("Denoising", float, apply_field("denoising_strength")),
     AxisOptionTxt2Img("Hires upscaler", str, apply_field("hr_upscaler"), choices=lambda: [*shared.latent_upscale_modes, *[x.name for x in shared.sd_upscalers]]),
+    AxisOptionTxt2Img("Fallback latent upscaler sampler", str, apply_fallback, format_value=format_value, confirm=confirm_samplers, choices=lambda: [x.name for x in sd_samplers.samplers]),
     AxisOptionImg2Img("Cond. Image Mask Weight", float, apply_field("inpainting_mask_weight")),
     AxisOption("VAE", str, apply_vae, cost=0.7, choices=lambda: list(sd_vae.vae_dict)),
     AxisOption("Styles", str, apply_styles, choices=lambda: list(shared.prompt_styles.styles)),


### PR DESCRIPTION
## Description

up til 3am last night hacking this thing together only to find that you implemented a nice fallback selector T_T

at least https://github.com/vladmandic/automatic/issues/562 is still help wanted :)

I don't really know what I'm doing, but the results seem pretty good:
https://i.imgur.com/asjxKgc.png

```
funny looking weiner dog
Steps: 25, Sampler: UniPC, CFG scale: 7, Seed: 1510552052, Size: 512x768, Model hash: 9aba26abdf, Model: deliberate_v2, VAE: deliberate_v2.vae, Denoising strength: 0.7, SAG Guidance Scale: 1.5, SAG Mask Threshold: 1, Hires upscale: 2, Hires steps: 5, Hires upscaler: Latent, UniPC variant: bh2
```

## Notes

this is my first go at anything to do with latent diffusion algos, so it was definitely brute force. the implementation in the huggingface repo wasn't too helpful since we're not diffusers (yet...? https://github.com/vladmandic/automatic/tree/diffusers :eyes:), but poking around the ddim img2img code I could kinda grok what was going on...

the noise injection in stochastic_encode doesn't actually seem necessary, but i only found that out after implementing it: https://github.com/huggingface/diffusers/blob/1d7b4b60b7b7e19a0347da5a04ec76c045d8dbf0/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_latent_upscale.py#L421-L424

and without that, the code in make_schedule is mostly unnecessary too? so this could probably be simpler...

also, there's probably various parameters i'm not passing through properly, or that we don't have but could use: https://github.com/vladmandic/automatic/blob/master/modules/models/diffusion/uni_pc/uni_pc.py#L803

## Environment and Testing

arch linux, some kind of torch nightly, 12.1 cuda installed but using 11.8 from torch binaries? i think?
4070ti, generation times for the 20 sample upscales were:
```
Progress 13.66it/s ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 0:00:01
100%|█████████████████████████████████████████████| 20/20 [00:13<00:00,  1.52it/s]
Progress 13.68it/s ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 0:00:01
100%|█████████████████████████████████████████████| 20/20 [00:13<00:00,  1.52it/s]
Progress 13.52it/s ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 0:00:01
Progress 2.13it/s ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 0:00:08
```