### PR TITLE
Moving Extra Network close button

### DIFF
--- a/javascript/extraNetworks.js
+++ b/javascript/extraNetworks.js
@@ -11,9 +11,8 @@ function setupExtraNetworksForTab(tabname){
     search.classList.add('search')
     tabs.appendChild(search)
     tabs.appendChild(refresh)
-    tabs.appendChild(descriptInput)
-    
     tabs.appendChild(close)
+    tabs.appendChild(descriptInput)
 
     search.addEventListener("input", function(evt){
         searchTerm = search.value.toLowerCase()


### PR DESCRIPTION
## Description

The new Extra Network Description section is neat, but it moved the close button for the Extra Networks tab underneath the textbox. This makes it appear that the close button is to clear the contents of the Description box. This change moves the close button next to the refresh button.

![image](https://user-images.githubusercontent.com/35073576/235244946-54855118-1a16-4e6f-8358-f8663cfbce0a.png)

## Notes

n/a

## Environment and Testing

Version: https://github.com/vladmandic/automatic/commit/eeea06b9
OS: Windows 11
Browser: Firefox 112.0.1 (64-bit)
