### PR TITLE
Fix typo that causes exception when training Textual Inversion

### DIFF
--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -526,7 +526,7 @@ def train_embedding(id_task, embedding_name, learn_rate, batch_size, gradient_st
                     save_embedding(embedding, optimizer, checkpoint, embedding_name_every, last_saved_file, remove_cached_checksum=True)
                     embedding_yet_to_be_embedded = True
 
-                write_loss(log_directory, shared.ops.embeddings_train_log, embedding.step, steps_per_epoch, {
+                write_loss(log_directory, shared.opts.embeddings_train_log, embedding.step, steps_per_epoch, {
                     "loss": f"{loss_step:.7f}",
                     "learn_rate": scheduler.learn_rate
                 })


### PR DESCRIPTION
There was a recent small typo in line 529.

shared.ops.embeddings_train_log caused an attribute not found exception when training TIs. 

Changed to shared.opts.embeddings_train_log
