### PR TITLE
Adding ToMe parameters to available x/y/z plot options

### DIFF
--- a/modules/generation_parameters_copypaste.py
+++ b/modules/generation_parameters_copypaste.py
@@ -316,7 +316,7 @@ infotext_to_setting_name_mapping = [
     ('Token merging merge attention', 'token_merging_merge_attention'),
     ('Token merging merge cross attention', 'token_merging_merge_cross_attention'),
     ('Token merging merge mlp', 'token_merging_merge_mlp'),
-    ('Token merging maximum downsampling', 'token_merging_maximum_downsampling'),
+    ('Token merging maximum downsampling', 'token_merging_maximum_down_sampling'),
     ('Token merging stride x', 'token_merging_stride_x'),
     ('Token merging stride y', 'token_merging_stride_y')
 ]

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -422,14 +422,14 @@ options_templates.update(options_section(('sampler-params', "Sampler parameters"
 
 options_templates.update(options_section(('token_merging', 'Token Merging'), {
     "token_merging": OptionInfo(False, "Enable redundant token merging via tomesd. This can provide significant speed and memory improvements.", gr.Checkbox),
-    "token_merging_ratio": OptionInfo(0.5, "Merging Ratio", gr.Slider, {"minimum": 0, "maximum": 0.9, "step": 0.1}),
+    "token_merging_ratio": OptionInfo(0.5, "Merging Ratio. Higher merging ratio = faster generation, smaller VRAM usage, lower quality.", gr.Slider, {"minimum": 0, "maximum": 0.9, "step": 0.1}),
     "token_merging_hr_only": OptionInfo(True, "Apply only to high-res fix pass. Disabling can yield a ~20-35% speedup on contemporary resolutions.", gr.Checkbox),
     "token_merging_ratio_hr": OptionInfo(0.5, "Merging Ratio (high-res pass) - If 'Apply only to high-res' is enabled, this will always be the ratio used.", gr.Slider, {"minimum": 0, "maximum": 0.9, "step": 0.1}),
     "token_merging_random": OptionInfo(False, "Use random perturbations - Can improve outputs for certain samplers. For others, it may cause visual artifacting.", gr.Checkbox),
-    "token_merging_merge_attention": OptionInfo(True, "Merge attention", gr.Checkbox),
-    "token_merging_merge_cross_attention": OptionInfo(False, "Merge cross attention", gr.Checkbox),
-    "token_merging_merge_mlp": OptionInfo(False, "Merge mlp", gr.Checkbox),
-    "token_merging_maximum_down_sampling": OptionInfo(1, "Maximum down sampling", gr.Dropdown, lambda: {"choices": ["1", "2", "4", "8"]}),
+    "token_merging_merge_attention": OptionInfo(True, "Merge attention (Recommend on)", gr.Checkbox),
+    "token_merging_merge_cross_attention": OptionInfo(False, "Merge cross attention (Recommend off)", gr.Checkbox),
+    "token_merging_merge_mlp": OptionInfo(False, "Merge mlp (Strongly recommend off)", gr.Checkbox),
+    "token_merging_maximum_down_sampling": OptionInfo(1, "Maximum down sampling", gr.Radio, lambda: {"choices": [1, 2, 4, 8]}),
     "token_merging_stride_x": OptionInfo(2, "Stride - X", gr.Slider, {"minimum": 2, "maximum": 8, "step": 2}),
     "token_merging_stride_y": OptionInfo(2, "Stride - Y", gr.Slider, {"minimum": 2, "maximum": 8, "step": 2})
 }))

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -151,34 +151,9 @@ def apply_token_merging_ratio_hr(p, x, xs):
 def apply_token_merging_ratio(p, x, xs):
     opts.data["token_merging_ratio"] = x
 
-def apply_token_merging_hr_only(p, x, xs):
-    is_active = x.lower() in ('true', 'yes', 'y', '1')
-    opts.data["token_merging_hr_only"] = is_active
-
 def apply_token_merging_random(p, x, xs):
     is_active = x.lower() in ('true', 'yes', 'y', '1')
     opts.data["token_merging_random"] = is_active
-
-def apply_token_merging_attention(p, x, xs):
-    is_active = x.lower() in ('true', 'yes', 'y', '1')
-    opts.data["token_merging_merge_attention"] = is_active
-
-def apply_token_merging_cross_attention(p, x, xs):
-    is_active = x.lower() in ('true', 'yes', 'y', '1')
-    opts.data["token_merging_merge_cross_attention"] = is_active
-
-def apply_token_merging_mlp(p, x, xs):
-    is_active = x.lower() in ('true', 'yes', 'y', '1')
-    opts.data["token_merging_merge_mlp"] = is_active
-
-def apply_token_merging_maximum_down_sampling (p, x, xs):
-    opts.data["token_merging_maximum_down_sampling"] = x
-
-def apply_token_merging_stride_x(p, x, xs):
-    opts.data["token_merging_stride_x"] = x
-
-def apply_token_merging_stride_y(p, x, xs):
-    opts.data["token_merging_stride_y"] = x
 
 def format_value_add_label(p, opt, x):
     if type(x) == float:
@@ -262,14 +237,7 @@ axis_options = [
     AxisOption("Face restore", str, apply_face_restore, format_value=format_value),
     AxisOption("ToMe ratio",float,apply_token_merging_ratio),
     AxisOption("ToMe ratio for Hires fix",float,apply_token_merging_ratio_hr),
-    AxisOption("ToMe apply only to Hires fix",str,apply_token_merging_hr_only, choices= lambda: ["Yes","No"]),
-    AxisOption("ToMe random pertubations",str,apply_token_merging_random, choices = lambda: ["Yes","No"]),
-    AxisOption("ToMe merge attention", str, apply_token_merging_attention, choices= lambda: ["Yes","No"]),
-    AxisOption("ToMe merge cross attention", str, apply_token_merging_cross_attention, choices= lambda: ["Yes","No"]),
-    AxisOption("ToMe merge mlp", str, apply_token_merging_mlp, choices= lambda: ["Yes","No"]),
-    AxisOption("ToMe maximum down sampling", int, apply_token_merging_maximum_down_sampling, choices= lambda: ["1","2","4","8"]),
-    AxisOption("ToMe Stride - X", int, apply_token_merging_stride_x, choices= lambda: ["2","4","6","8"]),
-    AxisOption("ToMe Stride - Y", int, apply_token_merging_stride_y, choices= lambda: ["2","4","6","8"])
+    AxisOption("ToMe random pertubations",str,apply_token_merging_random, choices = lambda: ["Yes","No"])
 ]
 
 
@@ -392,14 +360,7 @@ class SharedSettingsStackHelper(object):
         self.uni_pc_order = opts.uni_pc_order
         self.token_merging_ratio_hr = opts.token_merging_ratio_hr
         self.token_merging_ratio = opts.token_merging_ratio
-        self.token_merging_hr_only = opts.token_merging_hr_only
         self.token_merging_random = opts.token_merging_random
-        self.token_merging_merge_attention = opts.token_merging_merge_attention
-        self.token_merging_merge_cross_attention = opts.token_merging_merge_cross_attention
-        self.token_merging_merge_mlp = opts.token_merging_merge_mlp
-        self.token_merging_maximum_down_sampling = opts.token_merging_maximum_down_sampling
-        self.token_merging_stride_x = opts.token_merging_stride_x
-        self.token_merging_stride_y = opts.token_merging_stride_y
 
     def __exit__(self, exc_type, exc_value, tb):
         #Restore overriden settings after plot generation.
@@ -412,14 +373,7 @@ class SharedSettingsStackHelper(object):
 
         opts.data["token_merging_ratio_hr"] = self.token_merging_ratio_hr
         opts.data["token_merging_ratio"] = self.token_merging_ratio
-        opts.data["token_merging_hr_only"] = self.token_merging_hr_only
         opts.data["token_merging_random"] = self.token_merging_random
-        opts.data["token_merging_merge_attention"] = self.token_merging_merge_attention
-        opts.data["token_merging_merge_cross_attention"] = self.token_merging_merge_cross_attention
-        opts.data["token_merging_merge_mlp"] = self.token_merging_merge_mlp
-        opts.data["token_merging_maximum_down_sampling"] = self.token_merging_maximum_down_sampling
-        opts.data["token_merging_stride_x"] = self.token_merging_stride_x
-        opts.data["token_merging_stride_y"] = self.token_merging_stride_y
 
 re_range = re.compile(r"\s*([+-]?\s*\d+)\s*-\s*([+-]?\s*\d+)(?:\s*\(([+-]\d+)\s*\))?\s*")
 re_range_float = re.compile(r"\s*([+-]?\s*\d+(?:.\d*)?)\s*-\s*([+-]?\s*\d+(?:.\d*)?)(?:\s*\(([+-]\d+(?:.\d*)?)\s*\))?\s*")

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -260,16 +260,16 @@ axis_options = [
     AxisOption("Styles", str, apply_styles, choices=lambda: list(shared.prompt_styles.styles)),
     AxisOption("UniPC Order", int, apply_uni_pc_order, cost=0.5),
     AxisOption("Face restore", str, apply_face_restore, format_value=format_value),
-    AxisOption("Token merging ratio",float,apply_token_merging_ratio),
-    AxisOption("Token merging ratio for Hires fix",float,apply_token_merging_ratio_hr),
-    AxisOption("Token merging apply only to Hires fix",str,apply_token_merging_hr_only, choices= lambda: ["Yes","No"]),
-    AxisOption("Token Merging use random pertubations",str,apply_token_merging_random, choices = lambda: ["Yes","No"]),
-    AxisOption("Token Merging merge attention", str, apply_token_merging_attention, choices= lambda: ["Yes","No"]),
-    AxisOption("Token Merging merge cross attention", str, apply_token_merging_cross_attention, choices= lambda: ["Yes","No"]),
-    AxisOption("Token Merging merge mlp", str, apply_token_merging_mlp, choices= lambda: ["Yes","No"]),
-    AxisOption("Token Merging maxium down sampling", int, apply_token_merging_maximum_down_sampling, choices= lambda: ["1","2","4","8"]),
-    AxisOption("Token Merging Stride - X", int, apply_token_merging_stride_x, choices= lambda: ["2","4","6","8"]),
-    AxisOption("Token Merging Stride - Y", int, apply_token_merging_stride_y, choices= lambda: ["2","4","6","8"])
+    AxisOption("ToMe ratio",float,apply_token_merging_ratio),
+    AxisOption("ToMe ratio for Hires fix",float,apply_token_merging_ratio_hr),
+    AxisOption("ToMe apply only to Hires fix",str,apply_token_merging_hr_only, choices= lambda: ["Yes","No"]),
+    AxisOption("ToMe random pertubations",str,apply_token_merging_random, choices = lambda: ["Yes","No"]),
+    AxisOption("ToMe merge attention", str, apply_token_merging_attention, choices= lambda: ["Yes","No"]),
+    AxisOption("ToMe merge cross attention", str, apply_token_merging_cross_attention, choices= lambda: ["Yes","No"]),
+    AxisOption("ToMe merge mlp", str, apply_token_merging_mlp, choices= lambda: ["Yes","No"]),
+    AxisOption("ToMe maximum down sampling", int, apply_token_merging_maximum_down_sampling, choices= lambda: ["1","2","4","8"]),
+    AxisOption("ToMe Stride - X", int, apply_token_merging_stride_x, choices= lambda: ["2","4","6","8"]),
+    AxisOption("ToMe Stride - Y", int, apply_token_merging_stride_y, choices= lambda: ["2","4","6","8"])
 ]
 
 

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -145,6 +145,39 @@ def apply_face_restore(p, opt, x):
 
     p.restore_faces = is_active
 
+def apply_token_merging1(p, x, xs):
+    is_active = x.lower() in ('true', 'yes', 'y', '1')
+    p.override_settings["token_merging"] = is_active
+
+def apply_token_merging_ratio_hr(p, x, xs):
+    p.override_settings["token_merging_ratio_hr"] = x
+
+def apply_token_merging_ratio(p, x, xs):
+    p.override_settings["token_merging_ratio"] = x
+
+def apply_token_merging_hr_only(p, x, xs):
+    is_active = x.lower() in ('true', 'yes', 'y', '1')
+    p.override_settings["token_merging_hr_only"] = is_active
+
+def apply_token_merging_random(p, x, xs):
+    is_active = x.lower() in ('true', 'yes', 'y', '1')
+    p.override_settings["token_merging_random"] = is_active
+
+def apply_token_merging_attention(p, x, xs):
+    is_active = x.lower() in ('true', 'yes', 'y', '1')
+    p.override_settings["token_merging_merge_attention"] = is_active
+
+def apply_token_merging_cross_attention(p, x, xs):
+    is_active = x.lower() in ('true', 'yes', 'y', '1')
+    p.override_settings["token_merging_merge_cross_attention"] = is_active
+
+def apply_token_merging_mlp(p, x, xs):
+    is_active = x.lower() in ('true', 'yes', 'y', '1')
+    p.override_settings["token_merging_merge_mlp"] = is_active
+
+def apply_token_merging_maximum_down_sampling (p, x, xs):
+    p.override_settings["token_merging_maximum_down_sampling"] = x
+    #opts.data["token_merging_maximum_down_sampling"] = x
 
 def format_value_add_label(p, opt, x):
     if type(x) == float:
@@ -226,6 +259,15 @@ axis_options = [
     AxisOption("Styles", str, apply_styles, choices=lambda: list(shared.prompt_styles.styles)),
     AxisOption("UniPC Order", int, apply_uni_pc_order, cost=0.5),
     AxisOption("Face restore", str, apply_face_restore, format_value=format_value),
+    AxisOption("Token Merging", str, apply_token_merging1),
+    AxisOption("Token merging ratio",float,apply_token_merging_ratio),
+    AxisOption("Token merging ratio for Hires fix",float,apply_token_merging_ratio_hr),
+    AxisOption("Token merging apply only to Hires fix",str,apply_token_merging_hr_only, choices= lambda: ["Yes","No"]),
+    AxisOption("Token Merging use random pertubations",str,apply_token_merging_random, choices = lambda: ["Yes","No"]),
+    AxisOption("Token Merging merge attention", str, apply_token_merging_attention, choices= lambda: ["Yes","No"]),
+    AxisOption("Token Merging merge cross attention", str, apply_token_merging_cross_attention, choices= lambda: ["Yes","No"]),
+    AxisOption("Token Merging merge mlp", str, apply_token_merging_mlp, choices= lambda: ["Yes","No"]),
+    AxisOption("Token Merging maxium down sampling", int, apply_token_merging_maximum_down_sampling, choices= lambda: ["1","2","4","8"])
 ]
 
 

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -145,39 +145,40 @@ def apply_face_restore(p, opt, x):
 
     p.restore_faces = is_active
 
-def apply_token_merging1(p, x, xs):
-    is_active = x.lower() in ('true', 'yes', 'y', '1')
-    p.override_settings["token_merging"] = is_active
-
 def apply_token_merging_ratio_hr(p, x, xs):
-    p.override_settings["token_merging_ratio_hr"] = x
+    opts.data["token_merging_ratio_hr"] = x
 
 def apply_token_merging_ratio(p, x, xs):
-    p.override_settings["token_merging_ratio"] = x
+    opts.data["token_merging_ratio"] = x
 
 def apply_token_merging_hr_only(p, x, xs):
     is_active = x.lower() in ('true', 'yes', 'y', '1')
-    p.override_settings["token_merging_hr_only"] = is_active
+    opts.data["token_merging_hr_only"] = is_active
 
 def apply_token_merging_random(p, x, xs):
     is_active = x.lower() in ('true', 'yes', 'y', '1')
-    p.override_settings["token_merging_random"] = is_active
+    opts.data["token_merging_random"] = is_active
 
 def apply_token_merging_attention(p, x, xs):
     is_active = x.lower() in ('true', 'yes', 'y', '1')
-    p.override_settings["token_merging_merge_attention"] = is_active
+    opts.data["token_merging_merge_attention"] = is_active
 
 def apply_token_merging_cross_attention(p, x, xs):
     is_active = x.lower() in ('true', 'yes', 'y', '1')
-    p.override_settings["token_merging_merge_cross_attention"] = is_active
+    opts.data["token_merging_merge_cross_attention"] = is_active
 
 def apply_token_merging_mlp(p, x, xs):
     is_active = x.lower() in ('true', 'yes', 'y', '1')
-    p.override_settings["token_merging_merge_mlp"] = is_active
+    opts.data["token_merging_merge_mlp"] = is_active
 
 def apply_token_merging_maximum_down_sampling (p, x, xs):
-    p.override_settings["token_merging_maximum_down_sampling"] = x
-    #opts.data["token_merging_maximum_down_sampling"] = x
+    opts.data["token_merging_maximum_down_sampling"] = x
+
+def apply_token_merging_stride_x(p, x, xs):
+    opts.data["token_merging_stride_x"] = x
+
+def apply_token_merging_stride_y(p, x, xs):
+    opts.data["token_merging_stride_y"] = x
 
 def format_value_add_label(p, opt, x):
     if type(x) == float:
@@ -259,7 +260,6 @@ axis_options = [
     AxisOption("Styles", str, apply_styles, choices=lambda: list(shared.prompt_styles.styles)),
     AxisOption("UniPC Order", int, apply_uni_pc_order, cost=0.5),
     AxisOption("Face restore", str, apply_face_restore, format_value=format_value),
-    AxisOption("Token Merging", str, apply_token_merging1),
     AxisOption("Token merging ratio",float,apply_token_merging_ratio),
     AxisOption("Token merging ratio for Hires fix",float,apply_token_merging_ratio_hr),
     AxisOption("Token merging apply only to Hires fix",str,apply_token_merging_hr_only, choices= lambda: ["Yes","No"]),
@@ -267,7 +267,9 @@ axis_options = [
     AxisOption("Token Merging merge attention", str, apply_token_merging_attention, choices= lambda: ["Yes","No"]),
     AxisOption("Token Merging merge cross attention", str, apply_token_merging_cross_attention, choices= lambda: ["Yes","No"]),
     AxisOption("Token Merging merge mlp", str, apply_token_merging_mlp, choices= lambda: ["Yes","No"]),
-    AxisOption("Token Merging maxium down sampling", int, apply_token_merging_maximum_down_sampling, choices= lambda: ["1","2","4","8"])
+    AxisOption("Token Merging maxium down sampling", int, apply_token_merging_maximum_down_sampling, choices= lambda: ["1","2","4","8"]),
+    AxisOption("Token Merging Stride - X", int, apply_token_merging_stride_x, choices= lambda: ["2","4","6","8"]),
+    AxisOption("Token Merging Stride - Y", int, apply_token_merging_stride_y, choices= lambda: ["2","4","6","8"])
 ]
 
 
@@ -384,11 +386,23 @@ def draw_xyz_grid(p, xs, ys, zs, x_labels, y_labels, z_labels, cell, draw_legend
 
 class SharedSettingsStackHelper(object):
     def __enter__(self):
+        #Save overridden settings so they can be restored later.
         self.CLIP_stop_at_last_layers = opts.CLIP_stop_at_last_layers
         self.vae = opts.sd_vae
         self.uni_pc_order = opts.uni_pc_order
+        self.token_merging_ratio_hr = opts.token_merging_ratio_hr
+        self.token_merging_ratio = opts.token_merging_ratio
+        self.token_merging_hr_only = opts.token_merging_hr_only
+        self.token_merging_random = opts.token_merging_random
+        self.token_merging_merge_attention = opts.token_merging_merge_attention
+        self.token_merging_merge_cross_attention = opts.token_merging_merge_cross_attention
+        self.token_merging_merge_mlp = opts.token_merging_merge_mlp
+        self.token_merging_maximum_down_sampling = opts.token_merging_maximum_down_sampling
+        self.token_merging_stride_x = opts.token_merging_stride_x
+        self.token_merging_stride_y = opts.token_merging_stride_y
 
     def __exit__(self, exc_type, exc_value, tb):
+        #Restore overriden settings after plot generation.
         opts.data["sd_vae"] = self.vae
         opts.data["uni_pc_order"] = self.uni_pc_order
         sd_models.reload_model_weights()
@@ -396,6 +410,16 @@ class SharedSettingsStackHelper(object):
 
         opts.data["CLIP_stop_at_last_layers"] = self.CLIP_stop_at_last_layers
 
+        opts.data["token_merging_ratio_hr"] = self.token_merging_ratio_hr
+        opts.data["token_merging_ratio"] = self.token_merging_ratio
+        opts.data["token_merging_hr_only"] = self.token_merging_hr_only
+        opts.data["token_merging_random"] = self.token_merging_random
+        opts.data["token_merging_merge_attention"] = self.token_merging_merge_attention
+        opts.data["token_merging_merge_cross_attention"] = self.token_merging_merge_cross_attention
+        opts.data["token_merging_merge_mlp"] = self.token_merging_merge_mlp
+        opts.data["token_merging_maximum_down_sampling"] = self.token_merging_maximum_down_sampling
+        opts.data["token_merging_stride_x"] = self.token_merging_stride_x
+        opts.data["token_merging_stride_y"] = self.token_merging_stride_y
 
 re_range = re.compile(r"\s*([+-]?\s*\d+)\s*-\s*([+-]?\s*\d+)(?:\s*\(([+-]\d+)\s*\))?\s*")
 re_range_float = re.compile(r"\s*([+-]?\s*\d+(?:.\d*)?)\s*-\s*([+-]?\s*\d+(?:.\d*)?)(?:\s*\(([+-]\d+(?:.\d*)?)\s*\))?\s*")


### PR DESCRIPTION
This addresses 

- https://github.com/vladmandic/automatic/issues/532 
- a bug regarding the component for selecting maximum down sampling in the settings page https://github.com/vladmandic/automatic/issues/532#issuecomment-1524044984 

In addition, I have added some extra information to some ToMe settings based on the [original plugin author's comments](https://github.com/dbolya/tomesd/blob/2e37b87f2f24b0c902507b8afb7ebc7ba9b7cf6b/tomesd/patch.py#L196).  This should help the users get started with ToMe easier and preventing them from shooting their own feet (Enabling merge_mlp results in greatly reduced output quality). 

I have tested my change locally after rebasing to 6cd4d62f710a5c49dc6ff46a5dfb9ca93c8c5246

![xyz_grid-0241-3184478247-DPM++ 2M Karras-20-7-20230429184205](https://user-images.githubusercontent.com/1346257/235327032-df508ae6-6c3e-4d3d-a313-2d111b159d5c.jpg)