### PR TITLE
Use proper shebangs in cli scripts

### DIFF
--- a/cli/generate.py
+++ b/cli/generate.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 # pylint: disable=no-member
 """generate batches of images from prompts and upscale them
 

--- a/cli/modules/bench.py
+++ b/cli/modules/bench.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 """
 sd api txt2img benchmark
 """

--- a/cli/modules/grid.py
+++ b/cli/modules/grid.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 """
 Create image grid
 """

--- a/cli/modules/image-watermark.py
+++ b/cli/modules/image-watermark.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 import os
 import io
 import pathlib

--- a/cli/modules/interrogate-offline.py
+++ b/cli/modules/interrogate-offline.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 import os
 import gc

--- a/cli/modules/interrogate.py
+++ b/cli/modules/interrogate.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 """
 use clip to interrogate image(s)
 """

--- a/cli/modules/lora-extract.py
+++ b/cli/modules/lora-extract.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 """
 Extract approximating LoRA by SVD from two SD models

--- a/cli/modules/lora-latents.py
+++ b/cli/modules/lora-latents.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 import os
 import sys

--- a/cli/modules/models-diff.py
+++ b/cli/modules/models-diff.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 # based on <https://huggingface.co/JosephusCheung/ASimilarityCalculatior>
 
 import safetensors

--- a/cli/modules/palette-extract.py
+++ b/cli/modules/palette-extract.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 # based on <https://towardsdatascience.com/image-color-extraction-with-python-in-4-steps-8d9370d9216e>
 
 import os

--- a/cli/modules/preview-embeddings.py
+++ b/cli/modules/preview-embeddings.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 """
 create preview images from embeddings
 """

--- a/cli/modules/preview-models.py
+++ b/cli/modules/preview-models.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 import os
 import sys
 import json

--- a/cli/modules/process.py
+++ b/cli/modules/process.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 """
 process people images
 - check image resolution

--- a/cli/modules/prompt-ideas.py
+++ b/cli/modules/prompt-ideas.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 """
 generate prompt ideas
 model from: <https://huggingface.co/FredZhang7/distilgpt2-stable-diffusion-v2>

--- a/cli/modules/prompt-promptist.py
+++ b/cli/modules/prompt-promptist.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 """
 use microsoft promptist to beautify prompt
 - <https://huggingface.co/spaces/microsoft/Promptist>

--- a/cli/modules/sdapi.py
+++ b/cli/modules/sdapi.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 """
 helper methods that creates HTTP session with managed connection pool
 provides async HTTP get/post methods and several helper methods

--- a/cli/modules/train-losschart.py
+++ b/cli/modules/train-losschart.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 import io
 import os

--- a/cli/modules/train-lossrate.py
+++ b/cli/modules/train-lossrate.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 """
 auto-generate learn-rate
 """

--- a/cli/modules/util.py
+++ b/cli/modules/util.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 """
 generic helper methods
 """

--- a/cli/modules/video-extract.py
+++ b/cli/modules/video-extract.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 """
 use ffmpeg for animation processing
 """

--- a/cli/random/detectmodel.py
+++ b/cli/random/detectmodel.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 """
 Detect model type
 

--- a/cli/random/dynamotest.py
+++ b/cli/random/dynamotest.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 """
 Test Torch Dynamo functionality and backends
 """

--- a/cli/random/versions.py
+++ b/cli/random/versions.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 """
 print module versions
 """

--- a/cli/train-lora.py
+++ b/cli/train-lora.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 """
 Extract approximating LoRA by SVD from two SD models

--- a/cli/train-ti.py
+++ b/cli/train-ti.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 # pylint: disable=no-member
 """
 simple implementation of training api: `/sdapi/v1/train`

--- a/cli/train/latents.py
+++ b/cli/train/latents.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 import os
 import sys

--- a/cli/train/train.py
+++ b/cli/train/train.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 # system imports
 import os

--- a/cli/train/util.py
+++ b/cli/train/util.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 import os
 
 import transformers

--- a/cli/xformers.sh
+++ b/cli/xformers.sh
@@ -1,4 +1,4 @@
-#/bin/env bash
+#!/usr/bin/env bash
 echo "Installing xformers"
 
 NVCC_FLAGS="--use_fast_math" 


### PR DESCRIPTION
Many systems lack `/bin/env`, `/usr/bin/env` is more portable.