### PR TITLE
[UX] UniPC and PLMS as fallback, PLMS forced, settings consistency

### DIFF
--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -34,11 +34,9 @@ def set_samplers():
     shown_img2img = set(shared.opts.show_samplers)
 
     if len(shared.opts.show_samplers) == 0:
-        shown = set(['UniPC'])
+        shown = {'PLMS', 'UniPC'}
     else:
-        shown = set(shared.opts.show_samplers)
-
-    shown.add('PLMS')
+        shown = set(shared.opts.show_samplers + ['PLMS'])
 
     samplers = [x for x in all_samplers if x.name in shown]
     samplers_for_img2img = [x for x in all_samplers if x.name in shown_img2img]

--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -32,7 +32,13 @@ def set_samplers():
     global samplers, samplers_for_img2img
 
     shown_img2img = set(shared.opts.show_samplers)
-    shown = set(shared.opts.show_samplers + ['PLMS', 'UniPC'])
+
+    if len(shared.opts.show_samplers) == 0:
+        shown = set(['UniPC'])
+    else:
+        shown = set(shared.opts.show_samplers)
+
+    shown.add('PLMS')
 
     samplers = [x for x in all_samplers if x.name in shown]
     samplers_for_img2img = [x for x in all_samplers if x.name in shown_img2img]

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -424,7 +424,7 @@ options_templates.update(options_section(('ui', "Live previews"), {
 }))
 
 options_templates.update(options_section(('sampler-params', "Sampler parameters"), {
-    "show_samplers": OptionInfo(["Euler a", "UniPC", "DDIM", "DPM++ SDE", "DPM++ SDE", "DPM2 Karras", "DPM++ 2M Karras"], "Show samplers in user interface", gr.CheckboxGroup, lambda: {"choices": [x.name for x in list_samplers()]}),
+    "show_samplers": OptionInfo(["Euler a", "UniPC", "DDIM", "DPM++ SDE", "DPM++ SDE", "DPM2 Karras", "DPM++ 2M Karras"], "Show samplers in user interface", gr.CheckboxGroup, lambda: {"choices": [x.name for x in list_samplers() if x.name != "PLMS"]}),
     "fallback_sampler": OptionInfo("Euler a", "Secondary sampler", gr.Dropdown, lambda: {"choices": ["None"] + [x.name for x in list_samplers()]}),
     "eta_ancestral": OptionInfo(1.0, "Noise multiplier for ancestral samplers (eta)", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),
     "eta_ddim": OptionInfo(0.0, "Noise multiplier for DDIM (eta)", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -303,7 +303,14 @@ def create_output_panel(tabname, outdir):
 
 def create_sampler_and_steps_selection(choices, tabname):
     with FormRow(elem_id=f"sampler_selection_{tabname}"):
-        sampler_index = gr.Dropdown(label='Sampling method', elem_id=f"{tabname}_sampling", choices=[x.name for x in choices], value=choices[0].name if tabname == 'txt2img' else "Euler a", type="index")
+        if 'UniPC' in [sampler.name for sampler in choices]:
+            chosen_sampler_name = 'UniPC'
+        elif 'Euler a' in [sampler.name for sampler in choices]:
+            chosen_sampler_name = 'Euler a'
+        else:
+            chosen_sampler_name = samplers[0].name
+
+        sampler_index = gr.Dropdown(label='Sampling method', elem_id=f"{tabname}_sampling", choices=[x.name for x in choices], value=chosen_sampler_name if tabname == 'txt2img' else "Euler a", type="index")
         steps = gr.Slider(minimum=1, maximum=150, step=1, elem_id=f"{tabname}_steps", label="Sampling steps", value=20)
     return steps, sampler_index
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -303,7 +303,7 @@ def create_output_panel(tabname, outdir):
 
 def create_sampler_and_steps_selection(choices, tabname):
     with FormRow(elem_id=f"sampler_selection_{tabname}"):
-        sampler_index = gr.Dropdown(label='Sampling method', elem_id=f"{tabname}_sampling", choices=[x.name for x in choices], value="UniPC" if tabname == 'txt2img' else "Euler a", type="index")
+        sampler_index = gr.Dropdown(label='Sampling method', elem_id=f"{tabname}_sampling", choices=[x.name for x in choices], value=choices[0].name if tabname == 'txt2img' else "Euler a", type="index")
         steps = gr.Slider(minimum=1, maximum=150, step=1, elem_id=f"{tabname}_steps", label="Sampling steps", value=20)
     return steps, sampler_index
 


### PR DESCRIPTION
## Description

- remove PLMS from the samplers that can be selected/deselected since it should always be available
- check if the samplers list is empty, in which case force only UniPC and PLMS, otherwise only use the set of selected ones, with PLMS forced as part of the set of available samplers
- on load, select the first available sampler in UI ; this seems more expected than arbitrarily selecting UniPC which is the last one in the alphabetical list

Addressing https://github.com/vladmandic/automatic/issues/822