### PR TITLE
Fetch from API using relative path to avoid CORS errors

### DIFF
--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -290,7 +290,7 @@ function monitor_server_status() {
         <h1>Waiting for server...</h1>
         <script>
           function monitor_server_status() {
-            fetch('http://127.0.0.1:7860/sdapi/v1/progress')
+            fetch('/sdapi/v1/progress')
               .then((res) => { !res?.ok ? setTimeout(monitor_server_status, 1000) : location.reload(); })
               .catch((e) => setTimeout(monitor_server_status, 1000))
           }
@@ -305,7 +305,7 @@ function monitor_server_status() {
 function restart_reload() {
   document.body.style = 'background: #222222; font-size: 1rem; font-family:monospace; margin-top:20%; color:lightgray; text-align:center';
   document.body.innerHTML = '<h1>Server shutdown in progress...</h1>';
-  fetch('http://127.0.0.1:7860/sdapi/v1/progress')
+  fetch('/sdapi/v1/progress')
     .then((res) => setTimeout(restart_reload, 1000))
     .catch((e) => setTimeout(monitor_server_status, 500));
   return [];


### PR DESCRIPTION
## Description

In the `ui.js` script, the API address and port were hardcoded for the `monitor_server_status` and the `restart_reload` functions. If you run the application with a different configuration, the `fetch` will fail due to CORS restrictions.

The easiest fix I could think of is to simply use a relative path instead.

Thanks for your work, I love this version of the webui. 

## Notes

A more complex fix might have been injecting the relevant server configuration values into the front-end, maybe through the html templates. But I can't think of a scenario where the simple fix wouldn't work.

## Environment and Testing

- Windows 10
- Latest master branch
- Running bound to a local ip (not 127.0.01)
- Manually tested by using the restart button in Extensions, and making sure that the UI eventually refreshes on its own (through `monitor_server_status`)
