### PR TITLE
fix(#824): the installation of check_torch is overwritten

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,10 +41,8 @@ safetensors
 scipy
 tb_nightly
 toml
-torch
 torchdiffeq
 torchsde
-torchvision
 voluptuous
 yapf
 scikit-image


### PR DESCRIPTION
## Description

The problem about 
> I seem to have done something wrong. Although I specified the pystore version as' 2.0.0 'in' installer. py ', it seems to only take effect on the first run......During the second run of 'log. info (f'Tarch {torch. version}') ', the printed version is' 2.0.1', which still causes errors. This is a scene that I have never encountered before. I would like to ask for your advice.

## Notes

-

## Environment and Testing

- OS: MacOS 13.1
- Python: 3.10.9
