### PR TITLE
Implement Duplicate Extension Check in 'install_extensions()' Function

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -330,12 +330,28 @@ def list_extensions(folder):
 # run installer for each installed and enabled extension and optionally update them
 def install_extensions():
     from modules.paths_internal import extensions_builtin_dir, extensions_dir
+
+    # Initialize a dictionary to keep track of seen extensions
+    extensions_seen = {}
+
+    # Initialize a list to store the names of duplicate extensions
+    duplicates = []
+
     for folder in [extensions_builtin_dir, extensions_dir]:
         if not os.path.isdir(folder):
             continue
         extensions = list_extensions(folder)
+        
         log.info(f'Extensions enabled: {extensions}')
         for ext in extensions:
+            # Check if we've seen this extension before
+            # If we have, add it to the list of duplicates
+            # If not, add it to the dictionary of seen extensions
+            if ext in extensions_seen:
+                duplicates.append(ext)
+            else:
+                extensions_seen[ext] = True
+
             if not args.skip_update:
                 try:
                     update(os.path.join(folder, ext))
@@ -343,7 +359,9 @@ def install_extensions():
                     log.error(f'Error updating extension: {os.path.join(folder, ext)}')
             if not args.skip_extensions:
                 run_extension_installer(os.path.join(folder, ext))
-
+    # If there are any duplicates, log them in a single line, separated by commas
+    if duplicates:
+        log.warning(f'Duplicate extensions: {", ".join(duplicates)}')
 
 # initialize and optionally update submodules
 def install_submodules():

--- a/installer.py
+++ b/installer.py
@@ -330,28 +330,18 @@ def list_extensions(folder):
 # run installer for each installed and enabled extension and optionally update them
 def install_extensions():
     from modules.paths_internal import extensions_builtin_dir, extensions_dir
-
-    # Initialize a dictionary to keep track of seen extensions
-    extensions_seen = {}
-
-    # Initialize a list to store the names of duplicate extensions
-    duplicates = []
-
+    extensions_duplicates = []
+    extensions_enabled = []
     for folder in [extensions_builtin_dir, extensions_dir]:
         if not os.path.isdir(folder):
             continue
         extensions = list_extensions(folder)
-        
-        log.info(f'Extensions enabled: {extensions}')
+        log.debug(f'Extensions all: {extensions}')
         for ext in extensions:
-            # Check if we've seen this extension before
-            # If we have, add it to the list of duplicates
-            # If not, add it to the dictionary of seen extensions
-            if ext in extensions_seen:
-                duplicates.append(ext)
-            else:
-                extensions_seen[ext] = True
-
+            if ext in extensions_enabled:
+                extensions_duplicates.append(ext)
+                continue
+            extensions_enabled.append(ext)
             if not args.skip_update:
                 try:
                     update(os.path.join(folder, ext))
@@ -359,9 +349,10 @@ def install_extensions():
                     log.error(f'Error updating extension: {os.path.join(folder, ext)}')
             if not args.skip_extensions:
                 run_extension_installer(os.path.join(folder, ext))
-    # If there are any duplicates, log them in a single line, separated by commas
-    if duplicates:
-        log.warning(f'Duplicate extensions: {", ".join(duplicates)}')
+    log.info(f'Extensions enabled: {extensions_enabled}')
+    if (len(extensions_duplicates) > 0):
+        log.warning(f'Extensions duplicates: {extensions_duplicates}')
+
 
 # initialize and optionally update submodules
 def install_submodules():


### PR DESCRIPTION
Hey Bro,

figured I go scratch this one off your backlog ;) 

Title: Implement Duplicate Extension Check in install_extensions() Function

Description:

In this change, I have added functionality to the install_extensions() function in order to check for and log any duplicate extensions found across both the built-in and custom extensions directories.

This addition provides a level of error checking and prevents potential conflicts between extensions with the same name located in different directories. The function now maintains a dictionary of all encountered extensions, and logs any duplicates in a single line, separated by commas, at the end of the function execution.

This enhancement can help in debugging issues related to extension installations, such as unexpected behavior, crashes, or incorrect data being returned. By providing visibility into duplicate extensions, developers can more quickly identify and resolve these issues, resulting in a more robust and reliable application.

Moreover, logging duplicate extensions can be an important step in maintaining extension hygiene and ensuring the correct loading and running of extensions. This may be particularly helpful in environments with a large number of extensions or frequent updates and changes to extensions.

This change does not affect the existing functionality of installing and updating extensions. It remains fully backward-compatible with previous code and usage patterns.

Testing:
Tested on Windows but the changes are basic so shouldn't incur any issues on other OS's
