### PR TITLE
Simple Dockerfile and Container YAML with no Volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+FROM nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
+
+# Install apt packages
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    wget git python3 python3-venv \
+    libgl1 libglib2.0-0 \
+    libgoogle-perftools-dev \
+    && \
+    rm -rf /var/lib/apt/lists/*
+
+# Workaround: https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/6850
+ENV LD_PRELOAD=libtcmalloc.so
+
+# Workaround: https://gitlab.com/nvidia/container-images/cuda/-/issues/192
+RUN cd /usr/local/cuda/targets/x86_64-linux/lib && \
+    ln -sv libnvrtc.so.11.2 libnvrtc.so
+
+# Setup user and pick 1000 as the default UID for huggingface compatiblity
+ARG UID=1000
+RUN useradd -m -u $UID user
+USER user
+
+# Copy Local Files to Container
+COPY --chown=user . /webui
+
+# Setup venv and pip cache
+RUN python3 -m venv /webui/venv && \
+    mkdir -p /webui/cache/pip
+ENV PIP_CACHE_DIR=/webui/cache/pip
+
+# Install dependencies (pip, wheel)
+RUN . /webui/venv/bin/activate && \
+    pip install -U pip wheel
+
+# Install dependencies (torch)
+RUN . /webui/venv/bin/activate && \
+    pip install \
+    torch torchaudio torchvision --index-url https://download.pytorch.org/whl/cu118
+
+# Install dependencies (requirements.txt)
+RUN . /webui/venv/bin/activate && \
+    pip install -r /webui/requirements.txt
+
+# Clone repo and install dependencies (setup.py)
+RUN cd /webui && \
+    . /webui/venv/bin/activate && \
+    python installer.py
+
+STOPSIGNAL SIGINT
+ENTRYPOINT [ "bash", "/webui/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
 FROM nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
+# ARGS
+ARG UID=1000
+ARG INSTALLDIR="/webui"
+ENV RUNDIR ${INSTALLDIR}
 
 # Install apt packages
 RUN apt-get update && \
@@ -17,35 +21,36 @@ RUN cd /usr/local/cuda/targets/x86_64-linux/lib && \
     ln -sv libnvrtc.so.11.2 libnvrtc.so
 
 # Setup user and pick 1000 as the default UID for huggingface compatiblity
-ARG UID=1000
+
 RUN useradd -m -u $UID user
 USER user
 
 # Copy Local Files to Container
-COPY --chown=user . /webui
+COPY --chown=user . $INSTALLDIR
 
 # Setup venv and pip cache
-RUN python3 -m venv /webui/venv && \
-    mkdir -p /webui/cache/pip
-ENV PIP_CACHE_DIR=/webui/cache/pip
+RUN python3 -m venv $INSTALLDIR/venv && \
+    mkdir -p $INSTALLDIR/cache/pip
+ENV PIP_CACHE_DIR=$INSTALLDIR/cache/pip
 
 # Install dependencies (pip, wheel)
-RUN . /webui/venv/bin/activate && \
+RUN . $INSTALLDIR/venv/bin/activate && \
     pip install -U pip wheel
 
 # Install dependencies (torch)
-RUN . /webui/venv/bin/activate && \
+RUN . $INSTALLDIR/venv/bin/activate && \
     pip install \
     torch torchaudio torchvision --index-url https://download.pytorch.org/whl/cu118
 
 # Install dependencies (requirements.txt)
-RUN . /webui/venv/bin/activate && \
-    pip install -r /webui/requirements.txt
+RUN . $INSTALLDIR/venv/bin/activate && \
+    pip install -r $INSTALLDIR/requirements.txt
 
-# Clone repo and install dependencies (setup.py)
-RUN cd /webui && \
-    . /webui/venv/bin/activate && \
+# Install automatic111 dependencies (installer.py)
+RUN cd $INSTALLDIR && \
+    . $INSTALLDIR/venv/bin/activate && \
     python installer.py
 
 STOPSIGNAL SIGINT
-ENTRYPOINT [ "bash", "/webui/entrypoint.sh" ]
+# In order to pass variables along to Exec Form Bash, we need to copy them explicitly
+ENTRYPOINT ["/bin/bash", "-c", "${RUNDIR}/entrypoint.sh $0 $@"]

--- a/README.md
+++ b/README.md
@@ -148,6 +148,43 @@ The launcher can perform automatic update of main repository, requirements, exte
 
 ## Other
 
+### Docker Image
+
+The Dockerfile currently supports only NVIDIA GPUs and is made as simple as possible to work with HuggingFace Integrations.
+
+#### Requirement
+
+* [Docker](https://docs.docker.com/engine/install/)
+* [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)
+
+#### Setup
+
+- ARGS
+    - UID is the user ID for the Docker Container (default 1000 for hugging face)
+    - INSTALLDIR is the directory to install the container on the file system (default "/webui")
+
+- RUNNING
+
+      docker compose build
+
+#### Usage
+
+    docker compose up
+
+After startup, you can access to http://localhost:7860.
+
+#### Configure
+
+Create `docker-compose.override.yml` to change the command arguments or data location.
+
+```yaml
+services:
+  nvidia:
+    command: |
+      --data-dir=/webui/data
+      --listen
+```
+
 ### Scripts
 
 This repository comes with a large collection of scripts that can be used to process inputs, train, generate, and benchmark models  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.9"
+name: sd-automatic
+services:
+  nvidia:
+    build:
+      context: .
+      args:
+        UID: "1000"
+    command: |
+      --data-dir=/webui/repo/data
+      --listen
+    ports:
+      - "7860:7860"
+    tmpfs:
+      - /tmp
+    tty: true
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
       context: .
       args:
         UID: "1000"
+        INSTALLDIR: "/webui"
     command: |
-      --data-dir=/webui/repo/data
       --listen
     ports:
       - "7860:7860"

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -116,13 +116,11 @@ def list_models():
     shared.log.info(f'Available models: {shared.opts.ckpt_dir} {len(checkpoints_list)}')
     if len(checkpoints_list) == 0:
         if not shared.cmd_opts.no_download:
-            key = input('Download the default model? (y/N) ')
-            if key.lower().startswith('y'):
-                model_url = "https://huggingface.co/runwayml/stable-diffusion-v1-5/resolve/main/v1-5-pruned-emaonly.safetensors"
-                model_list = modelloader.load_models(model_path=model_path, model_url=model_url, command_path=shared.opts.ckpt_dir, ext_filter=[".ckpt", ".safetensors"], download_name="v1-5-pruned-emaonly.safetensors", ext_blacklist=[".vae.ckpt", ".vae.safetensors"])
-                for filename in sorted(model_list, key=str.lower):
-                    checkpoint_info = CheckpointInfo(filename)
-                    checkpoint_info.register()
+            model_url = "https://huggingface.co/runwayml/stable-diffusion-v1-5/resolve/main/v1-5-pruned-emaonly.safetensors"
+            model_list = modelloader.load_models(model_path=model_path, model_url=model_url, command_path=shared.opts.ckpt_dir, ext_filter=[".ckpt", ".safetensors"], download_name="v1-5-pruned-emaonly.safetensors", ext_blacklist=[".vae.ckpt", ".vae.safetensors"])
+            for filename in sorted(model_list, key=str.lower):
+                checkpoint_info = CheckpointInfo(filename)
+                checkpoint_info.register()
 
 
 def get_closet_checkpoint_match(search_string):


### PR DESCRIPTION
## Description

Recently, someone attempted a patch with a Dockerfile that was fairly specific to their needs. I just wanted to create a simplified container with minimal requirements that works on the core directory installed on the machine instead of doing all the weird volume mounting and re-cloning of the repo of the previous one that was posted.

## Notes

I stuck with the simplest possible system that I think would work with the least opinions on the system possible. It has 2 args
- UID for setting specific userID's for various Docker environments if needed
- INSTALLDIR for picking where the files go

Because of Docker, I had to use an ENV var in the EXEC entrypoint to allow for changes to the Installation directory.

I don't do any pip caching so subsequent runs take the full time as I am using this for HuggingFace spaces and they don't save docker files between runs.

It's the most generic thing I could think of that works but would be happy to patch if someone can think of more general solution. As it stands, you can just ```docker compose build``` and ```docker compose up``` if you have the Docker and Nvidia link all set up on your box and it works.  For that, I removed the input part of sd_models.py so it loads at least one model without any user input (which obviously isn't available in the container entry script).

## Environment and Testing

Windows 10, Docker 23.0.5
