### PR TITLE
fix prompts from file script failing to read contents from a drag/drop file

### DIFF
--- a/scripts/prompts_from_file.py
+++ b/scripts/prompts_from_file.py
@@ -94,11 +94,10 @@ def cmdargs(line):
 
 def load_prompt_file(file):
     if file is None:
-        lines = []
+        return None, gr.update(), gr.update(lines=7)
     else:
         lines = [x.strip() for x in file.decode('utf8', errors='ignore').split("\n")]
-
-    return None, "\n".join(lines), gr.update(lines=7)
+        return None, "\n".join(lines), gr.update(lines=7)
 
 
 class Script(scripts.Script):
@@ -112,12 +111,12 @@ class Script(scripts.Script):
         prompt_txt = gr.Textbox(label="List of prompt inputs", lines=1, elem_id=self.elem_id("prompt_txt"))
         file = gr.File(label="Upload prompt inputs", type='binary', elem_id=self.elem_id("file"))
 
-        file.change(fn=load_prompt_file, inputs=[file], outputs=[file, prompt_txt, prompt_txt])
+        file.change(fn=load_prompt_file, inputs=[file], outputs=[file, prompt_txt, prompt_txt], show_progress=False)
 
         # We start at one line. When the text changes, we jump to seven lines, or two lines if no \n.
         # We don't shrink back to 1, because that causes the control to ignore [enter], and it may
         # be unclear to the user that shift-enter is needed.
-        prompt_txt.change(lambda tb: gr.update(lines=7) if ("\n" in tb) else gr.update(lines=2), inputs=[prompt_txt], outputs=[prompt_txt])
+        prompt_txt.change(lambda tb: gr.update(lines=7) if ("\n" in tb) else gr.update(lines=2), inputs=[prompt_txt], outputs=[prompt_txt], show_progress=False)
         return [checkbox_iterate, checkbox_iterate_batch, prompt_txt]
 
     def run(self, p, checkbox_iterate, checkbox_iterate_batch, prompt_txt: str):


### PR DESCRIPTION
## Description

When using the `Prompts from file` Script, it is not possible to use files containing the prompts. For whatever reason it only shows up the content for a glimpse of time and then disappears.

While searching for a solution i found, that AUTOMATIC1111 fixed the problem a few days ago:

https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/8ca50f8240fc1b4400ba59be50ad7a75b99cfbcb

So i implemented these changes locally and they worked.

## Notes

I'm no programmer and just did some copy & paste. So please check - especially with your made changes for the new extension manager - if my changes are correct.

## Environment and Testing

```
Using VENV: D:\AI\sdvlad\venv
12:57:16-321889 INFO     Starting SD.Next
12:57:16-353057 INFO     Python 3.10.11 on Windows
12:57:16-685640 INFO     Version: 926b8666 Sat May 13 16:42:01 2023 -0400
12:57:17-239919 INFO     Setting environment tuning
12:57:17-239919 INFO     nVidia CUDA toolkit detected
12:57:28-481235 INFO     Torch 2.0.0+cu118
12:57:28-549889 INFO     Torch backend: nVidia CUDA 11.8 cuDNN 8700
12:57:28-549889 INFO     Torch detected GPU: NVIDIA GeForce GTX 1080 Ti VRAM 11264 Arch (6, 1) Cores 28
```
