### PR TITLE
Don't read log if load is forced.

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -622,12 +622,13 @@ def parse_args():
 
 def extensions_preload(force = False):
     setup_time = 0
-    if os.path.isfile('setup.log'):
-        with open('setup.log', 'r', encoding='utf8') as f:
-            lines = f.readlines()
-            for line in lines:
-                if 'Setup complete without errors' in line:
-                    setup_time = int(line.split(' ')[-1])
+    if not force:
+        if os.path.isfile('setup.log'):
+            with open('setup.log', 'r', encoding='utf8') as f:
+                lines = f.readlines()
+                for line in lines:
+                    if 'Setup complete without errors' in line:
+                        setup_time = int(line.split(' ')[-1])
     if setup_time > 0 or force:
         log.info('Running extension preloading')
         if args.safe:


### PR DESCRIPTION
## Description

Small efficiency improvement - if force=True, scanning the log is meaningless.

## Notes

More technical discussion about your changes go here, plus anything that a maintainer might have to specifically take a look at, or be wary of

## Environment and Testing

List the environment you have developed / tested this on
