### PR TITLE
(FIX) The newly re-added --api-only doesn't have an entry in modules/cmd_args.py

### DIFF
--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -27,6 +27,7 @@ group.add_argument("--authfile", type=str, help='Set access authentication using
 group.add_argument("--autolaunch", action='store_true', help="Open the UI URL in the system's default browser upon launch", default=False)
 group.add_argument("--api-auth", type=str, help='Set API authentication, default: %(default)s', default=None)
 group.add_argument("--api-log", default=False, action='store_true', help="Enable logging of all API requests, default: %(default)s")
+group.add_argument("--api-only", action='store_true', help="Run in API-Only Mode.", default=False)
 group.add_argument("--device-id", type=str, help="Select the default CUDA device to use, default: %(default)s", default=None)
 group.add_argument("--cors-origins", type=str, help="Allowed CORS origins as comma-separated list, default: %(default)s", default=None)
 group.add_argument("--cors-regex", type=str, help="Allowed CORS origins as regular expression, default: %(default)s", default=None)


### PR DESCRIPTION
## Description

Running `webui.py` normally fails.
```
│ /stable-diffusion-webui/webui.py:306 in <module>                                                                                                                                                                          │
│                                                                                                                                                                                                                           │
│   305     print(cmd_opts)                                                                                                                                                                                                 │
│ ❱ 306     if cmd_opts.api_only:                                                                                                                                                                                           │
│   307         api_only()                                                                                                                                                                                                  │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
AttributeError: 'Namespace' object has no attribute 'api_only'
```
This causes `webui.py` to exit. 

## Notes

I traced this back to needing to include `--api-only` in the `modules/cmd_args.py` file.

## Environment and Testing

Linux/Docker
