### PR TITLE
Skip git check in `check_python()` when `args.skip_git` is True

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -227,11 +227,12 @@ def check_python():
         log.error(f"Incompatible Python version: {sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro} required 3.{supported_minors}")
         if not args.ignore:
             exit(1)
-    git_cmd = os.environ.get('GIT', "git")
-    if shutil.which(git_cmd) is None:
-        log.error('Git not found')
-        if not args.ignore:
-            exit(1)
+    if not args.skip_git:
+        git_cmd = os.environ.get('GIT', "git")
+        if shutil.which(git_cmd) is None:
+            log.error('Git not found')
+            if not args.ignore:
+                exit(1)
     else:
         git_version = git('--version', folder=None, ignore=False)
         log.debug(f'Git {git_version.replace("git version", "").strip()}')


### PR DESCRIPTION
## Description

Currently even with the `--skip-git` flag on, start-up fails due to `check_python()` failing during `shutil.which(git_cmd)` and exiting.

This PR adds `if not args.skip_git` before the git_cmd check, and it should now be possible to launch normally on systems without git installed.