### PR TITLE
Raise exception when failing to find diffuser model

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -50,8 +50,9 @@ class CheckpointInfo:
         else: # TODO Diffusers
             repo = [r for r in modelloader.diffuser_repos if filename == r['filename']]
             if len(repo) == 0:
-                shared.log.error(f'Cannot find diffuser model: {filename}')
-                return
+                error_message = f'Cannot find diffuser model: {filename}'
+                shared.log.error(error_message)
+                raise ValueError(error_message)
             self.name = repo[0]['name']
             self.hash = repo[0]['hash'][:8]
             self.sha256 = repo[0]['hash']


### PR DESCRIPTION
## Description

When the CheckpointInfo can't find a Diffuser model, right now it logs a warning and returns early.
This leads to an AttributeError later on when trying to access the title attribute which isn't set.

This PR makes the source of the issue explicit by raising the Error early.

## Notes

N/A

## Environment and Testing

Windows 10
