### PR TITLE
fix unipc inpainting

### DIFF
--- a/modules/sd_samplers_compvis.py
+++ b/modules/sd_samplers_compvis.py
@@ -104,10 +104,10 @@ class VanillaStableDiffusionSampler:
             unconditional_conditioning = unconditional_conditioning[:, :cond.shape[1]]
 
         if self.mask is not None:
-            if shared.cmd_opts.use_ipex:
-                img_orig = self.sampler.model.q_sample(self.init_latent, ts.type(torch.int64))
-            else:
-                img_orig = self.sampler.model.q_sample(self.init_latent, ts)
+            encode_fn = self.sampler.model.q_sample
+            if self.is_unipc:
+                encode_fn = self.sampler.stochastic_encode
+            img_orig = encode_fn(self.init_latent, ts)
             x = img_orig * self.mask + self.nmask * x
 
         # Wrap the image conditioning back up since the DDIM code can accept the dict directly.


### PR DESCRIPTION
## Description

fix for https://github.com/vladmandic/automatic/discussions/1212

## Notes

this change is based almost entirely off of `q_sample` and the `stochastic_encode` i implemented for UniPC both appearing to do the same thing. the method swap also works for other samplers, but doesn't work for DDIM so it's limited to UniPC for now.

## Environment and Testing

```
17:33:05-567083 INFO     Torch 2.1.0.dev20230529+cu121
17:33:05-569708 INFO     Torch backend: nVidia CUDA 12.1 cuDNN 8801
17:33:05-577268 INFO     Torch detected GPU: NVIDIA GeForce RTX 4070 Ti VRAM 12007 Arch (8, 9) Cores 60
```

tested through a few inpainting runs, X/Y/Z with all samplers, various infills like latent noise and original