### PR TITLE
Fix train.py

### DIFF
--- a/cli/train.py
+++ b/cli/train.py
@@ -120,7 +120,7 @@ def parse_args():
 
 def prepare_server():
     try:
-        server_status = util.Map(sdapi.progress())
+        server_status = util.Map(asyncio.run(sdapi.progress()))
         server_state = server_status['state']
     except:
         log.error(f'server error: {server_status}')


### PR DESCRIPTION
## Description
Looks like `sdapi.progress()` is async but was not `await`ed. This change allows training to not crash (as long as `sd-scripts` is also [updated with this fix](https://github.com/kohya-ss/sd-scripts/pull/468))

## Notes
I was running this:
```
python train.py --type lora --name myName --tag myTag --input /workspace/out
```

And it was throwing the following error:

```
root@5965793b718e:/workspace/automatic/cli# NUMEXPR_MAX_THREADS=24 python train.py --type lora --name myName  --tag myTag --input /workspace/out
2023-06-02 15:12:25.712945: I tensorflow/core/util/port.cc:110] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
2023-06-02 15:12:25.748380: I tensorflow/core/platform/cpu_feature_guard.cc:182] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.
To enable the following instructions: AVX2 AVX512F AVX512_VNNI FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
2023-06-02 15:12:26.413663: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Could not find TensorRT
2023-06-02 15:12:28,101 INFO: SD.Next train script
╭─────────────────────────────────────────────────────────── Traceback (most recent call last) ────────────────────────────────────────────────────────────╮
│ /workspace/automatic/cli/train.py:123 in prepare_server                                                                                                  │
│                                                                                                                                                          │
│   122     try:                                                                                                                                           │
│ ❱ 123         server_status = util.Map(sdapi.progress())                                                                                                 │
│   124         server_state = server_status['state']                                                                                                      │
│                                                                                                                                                          │
│ /workspace/automatic/cli/util.py:76 in __init__                                                                                                          │
│                                                                                                                                                          │
│    75     def __init__(self, *args, **kwargs):                                                                                                           │
│ ❱  76         super(Map, self).__init__(*args, **kwargs)                                                                                                 │
│    77         for arg in args:                                                                                                                           │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
TypeError: 'coroutine' object is not iterable

During handling of the above exception, another exception occurred:

╭─────────────────────────────────────────────────────────── Traceback (most recent call last) ────────────────────────────────────────────────────────────╮
│ /workspace/automatic/cli/train.py:380 in <module>                                                                                                        │
│                                                                                                                                                          │
│   379     setup_logging()                                                                                                                                │
│ ❱ 380     prepare_server()                                                                                                                               │
│   381     verify_args()                                                                                                                                  │
│                                                                                                                                                          │
│ /workspace/automatic/cli/train.py:126 in prepare_server                                                                                                  │
│                                                                                                                                                          │
│   125     except:                                                                                                                                        │
│ ❱ 126         log.error(f'server error: {server_status}')                                                                                                │
│   127         exit(1)                                                                                                                                    │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
UnboundLocalError: local variable 'server_status' referenced before assignment
```

## Environment and Testing
Docker container, running latest `origin/master`
