### PR TITLE
add new VAE encoding strategy during HR fix

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -282,6 +282,7 @@ options_templates.update(options_section(('sd', "Stable Diffusion"), {
     "sd_checkpoint_cache": OptionInfo(0, "Model checkpoints to cache in RAM", gr.Slider, {"minimum": 0, "maximum": 10, "step": 1}),
     "sd_vae_checkpoint_cache": OptionInfo(0, "VAE checkpoints to cache in RAM", gr.Slider, {"minimum": 0, "maximum": 10, "step": 1}),
     "sd_vae": OptionInfo("Automatic", "Select VAE", gr.Dropdown, lambda: {"choices": shared_items.sd_vae_items()}, refresh=shared_items.refresh_vae_list),
+    "sd_vae_sliced_encode": OptionInfo(False, "During HR fix, encode each image in a batch separately"),
     "stream_load": OptionInfo(False, "When loading models attempt stream loading optimized for slow or network storage"),
     "model_reuse_dict": OptionInfo(False, "When loading models attempt to reuse previous model dictionary"),
     "cross_attention_optimization": OptionInfo(cross_attention_optimization_default, "Cross-attention optimization method", gr.Radio, lambda: {"choices": shared_items.list_crossattention() }),


### PR DESCRIPTION
## Description

not sure what changed recently, but i've been super sad about needing to use tiled VAE encoding with any batch size above 1. the diffusers docs mentions two methods for saving VRAM related to the VAE, tiling *and* slicing: https://huggingface.co/docs/diffusers/optimization/fp16#sliced-vae-decode-for-larger-batches

i'm not sure why, but slicing is only implemented for decode in their implementation, and we're doing that already as well (i think). so i gave it a shot and implemented it in the most ignorant way that worked, but it does work!


## Notes

previously i couldn't generate with a batch of 2 + non-latent HR fix, but with this option on i've done batches of up to 8. adds a small bit of latency encoding the upscaled images individually, but overall it seems to be faster than the tiled encode. i still do have to use the tiled encode, but overall it's acceptably fast and actually *works* at larger batch sizes for me now.

not sure if this conflicts with any extensions, but i've tested at least SAG, dynamic prompts, and tiled VAE decode.

## Environment and Testing

```
19:35:22-663657 INFO     Torch 2.0.1
19:35:22-666989 INFO     Torch backend: nVidia CUDA 12.1 cuDNN 8900
19:35:22-674540 INFO     Torch detected GPU: NVIDIA GeForce RTX 4070 Ti VRAM 12007 Arch (8, 9) Cores 60
```