### PR TITLE
Add diffusers checkpoint downloader

### DIFF
--- a/javascript/black-orange.css
+++ b/javascript/black-orange.css
@@ -79,6 +79,8 @@ svg.feather.feather-image, .feather .feather-image { display: none }
 #lightboxModal { background-color: rgba(20, 20, 20, 0.8) }
 #quicksettings .gr-button-tool { font-size: 1.6rem; box-shadow: none; margin-left: -20px; margin-top: -2px; height: 2.4em; }
 #quicksettings > div, #quicksettings > fieldset { min-width: 24em; max-width: 26em; line-height: 2em; }
+#hub_downloads .gr-button-tool { font-size: 1.6rem; box-shadow: none; margin-left: -20px; margin-top: -2px; height: 2.4em; }
+#hub_downloads > div, #hub_downloads > fieldset { min-width: 24em; max-width: 26em; line-height: 2em; }
 #refresh_sd_model_checkpoint { height: 48px; margin-left: -14px; background: #333333; box-shadow: none; }
 #open_folder_extras, #footer, #style_pos_col, #style_neg_col, #roll_col, #extras_upscaler_2, #extras_upscaler_2_visibility, #txt2img_seed_resize_from_w, #txt2img_seed_resize_from_h { display: none; }
 #save-animation { border-radius: 0 !important; margin-bottom: 16px; background-color: #111111; }

--- a/javascript/style.css
+++ b/javascript/style.css
@@ -214,6 +214,15 @@ div#extras_scale_to_tab div.form{
     background: none;
 }
 
+#hub_downloads > div, #hub_downloads > fieldset{
+    max-width: 24em;
+    min-width: 24em;
+    padding: 0;
+    border: none;
+    box-shadow: none;
+    background: none;
+}
+
 #settings{
     display: block;
 }

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -15,6 +15,7 @@ import modules.memmon
 import modules.styles
 import modules.devices as devices
 import modules.paths_internal as paths
+from diffusers import DiffusionPipeline 
 from installer import log as central_logger # pylint: disable=E0611
 
 
@@ -185,7 +186,7 @@ state.server_start = time.time()
 
 
 class OptionInfo:
-    def __init__(self, default=None, label="", component=None, component_args=None, onchange=None, section=None, refresh=None, comment_before='', comment_after=''):
+    def __init__(self, default=None, label="", component=None, component_args=None, onchange=None, section=None, refresh=None, submit=None, comment_before='', comment_after=''):
         self.default = default
         self.label = label
         self.component = component
@@ -195,6 +196,7 @@ class OptionInfo:
         self.refresh = refresh
         self.comment_before = comment_before # HTML text that will be added after label in UI
         self.comment_after = comment_after # HTML text that will be added before label in UI
+        self.submit = submit
 
     def link(self, label, uri):
         self.comment_before += f"[<a href='{uri}' target='_blank'>{label}</a>]"
@@ -223,9 +225,12 @@ def list_checkpoint_tiles():
     import modules.sd_models # pylint: disable=W0621
     return modules.sd_models.checkpoint_tiles()
 
-
 default_checkpoint = list_checkpoint_tiles()[0] if len(list_checkpoint_tiles()) > 0 else "model.ckpt"
 
+def load_diffusers_ckpt(model_repo: str):
+    cached_dir = DiffusionPipeline.download(model_repo, cache_dir=opts.data["diffusers_dir"])
+    print(f"Downloaded {cached_dir}")
+    return ""
 
 def refresh_checkpoints():
     import modules.sd_models # pylint: disable=W0621
@@ -410,6 +415,8 @@ options_templates.update(options_section(('ui', "User interface"), {
     "keyedit_precision_extra": OptionInfo(0.05, "Ctrl+up/down precision when editing <extra networks:0.9>", gr.Slider, {"minimum": 0.01, "maximum": 0.2, "step": 0.001}),
     "keyedit_delimiters": OptionInfo(".,\/!?%^*;:{}=`~()", "Ctrl+up/down word delimiters"), # pylint: disable=anomalous-backslash-in-string
     "quicksettings_list": OptionInfo(["sd_model_checkpoint"], "Quicksettings list", ui_components.DropdownMulti, lambda: {"choices": list(opts.data_labels.keys())}),
+    "diffusers_ckpt_download": OptionInfo("", "🤗 Hub Checkpoint Download", gr.Textbox, {"placeholder": "e.g. runwayml/stable-diffusion-v1-5"}, submit=load_diffusers_ckpt),
+    "diffusers_download_list": OptionInfo(["diffusers_ckpt_download"], "Diffusers Download list", ui_components.DropdownMulti, lambda: {"choices": list(opts.data_labels.keys())}),
     "hidden_tabs": OptionInfo([], "Hidden UI tabs", ui_components.DropdownMulti, lambda: {"choices": [x for x in tab_names]}),
     "ui_tab_reorder": OptionInfo("From Text, From Image, Process Image", "UI tabs order"),
     "ui_scripts_reorder": OptionInfo("Enable Dynamic Thresholding, ControlNet", "UI scripts order"),

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1336,6 +1336,9 @@ def create_ui():
         quicksettings_names = opts.quicksettings_list
         quicksettings_names = {x: i for i, x in enumerate(quicksettings_names) if x != 'quicksettings'}
         quicksettings_list = []
+        diffusers_downloads = opts.diffusers_download_list
+        diffusers_download_list = []
+
         previous_section = None
         current_tab = None
         current_row = None
@@ -1355,6 +1358,9 @@ def create_ui():
                     previous_section = item.section
                 if k in quicksettings_names and not modules.shared.cmd_opts.freeze:
                     quicksettings_list.append((i, k, item))
+                    components.append(dummy_component)
+                if k in diffusers_downloads and not modules.shared.cmd_opts.freeze and backend == Backend.DIFFUSERS:
+                    diffusers_download_list.append((i, k, item))
                     components.append(dummy_component)
                 elif section_must_be_skipped:
                     components.append(dummy_component)
@@ -1423,7 +1429,7 @@ def create_ui():
 
     with gr.Blocks(theme=modules.shared.gradio_theme, analytics_enabled=False, title="SD.Next", allowed_paths=[cmd_opts.data_dir]) as demo:
         with gr.Row(elem_id="quicksettings", variant="compact"):
-            for i, k, item in sorted(quicksettings_list, key=lambda x: quicksettings_names.get(x[1], x[0])):
+            for i, k, item in sorted(quicksettings_list + diffusers_download_list, key=lambda x: quicksettings_names.get(x[1], x[0])):
                 component = create_setting_component(k, is_quicksettings=True)
                 component_dict[k] = component
 
@@ -1459,6 +1465,17 @@ def create_ui():
                 inputs=[component],
                 outputs=[component, text_settings],
                 show_progress=info.refresh is not None,
+            )
+
+        for i, k, item in diffusers_download_list:
+            component = component_dict[k]
+            info = opts.data_labels[k]
+
+            component.submit(
+                fn=info.submit,
+                inputs=[component],
+                outputs=[component],
+                show_progress=True
             )
 
         image_cfg_scale_visibility = (modules.shared.sd_model is not None) and hasattr(modules.shared.sd_model, 'cond_stage_key') and (modules.shared.sd_model.cond_stage_key == "edit") # pix2pix

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1429,9 +1429,15 @@ def create_ui():
 
     with gr.Blocks(theme=modules.shared.gradio_theme, analytics_enabled=False, title="SD.Next", allowed_paths=[cmd_opts.data_dir]) as demo:
         with gr.Row(elem_id="quicksettings", variant="compact"):
-            for i, k, item in sorted(quicksettings_list + diffusers_download_list, key=lambda x: quicksettings_names.get(x[1], x[0])):
+            for i, k, item in sorted(quicksettings_list, key=lambda x: quicksettings_names.get(x[1], x[0])):
                 component = create_setting_component(k, is_quicksettings=True)
                 component_dict[k] = component
+
+        with gr.Row(elem_id="hub_downloads"):
+            if backend == Backend.DIFFUSERS:
+                for i, k, item in sorted(diffusers_download_list, key=lambda x: x[0]):
+                    component = create_setting_component(k)
+                    component_dict[k] = component
 
         parameters_copypaste.connect_paste_params_buttons()
 


### PR DESCRIPTION
## Description

When starting with `diffusers` backend, add a simple gradio text field that allows to download any diffusers checkpoint.

## Notes

Chose this design pattern as one could nicely extend this in the future to just download `diffusers` ControlNet, Textual Inversion, LoRA, ... checkpoints.

## Environment and Testing

Testing on Linux, but it's just UI so should be fine.

![Screenshot from 2023-06-07 01-41-04](https://github.com/vladmandic/automatic/assets/23423619/6a95d4cb-c8de-4ba2-ab39-50512f777584)

