### PR TITLE
Fix reload callbacks order

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -298,6 +298,10 @@ def start_ui():
 
 
 def webui(restart=False):
+    if restart:
+        modules.script_callbacks.app_reload_callback()
+        modules.script_callbacks.script_unloaded_callback()
+
     start_common()
     start_ui()
     modules.sd_models.write_metadata()
@@ -321,8 +325,6 @@ def webui(restart=False):
             import webbrowser
             webbrowser.open(local_url, new=2, autoraise=True)
     else:
-        modules.script_callbacks.app_reload_callback()
-        modules.script_callbacks.script_unloaded_callback()
         for module in [module for name, module in sys.modules.items() if name.startswith("modules.ui")]:
             importlib.reload(module)
 


### PR DESCRIPTION
## Description

Fix the reload callbacks to fire the old ones instead of the new ones. This is done by moving the reload callbacks registration to before `start_common()`.

## Notes

N/A

## Environment and Testing

Tested on macOS M1.
