### PR TITLE
:bug: Handle JSON escape issue in logger

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -58,7 +58,9 @@ def setup_logging():
             self.formatter = logging.Formatter('{ "asctime":"%(asctime)s", "created":%(created)f, "facility":"%(name)s", "pid":%(process)d, "tid":%(thread)d, "level":"%(levelname)s", "module":"%(module)s", "func":"%(funcName)s", "msg":"%(message)s" }')
 
         def emit(self, record):
-            msg = self.format(record)
+            # Replace '\\' with '\\\\' so that json decoder can correctly receive
+            # the unescaped value '\'.
+            msg = self.format(record).replace('\\', '\\\\')
             self.buffer.append(json.loads(msg))
             if len(self.buffer) > self.capacity:
                 self.buffer.pop(0)


### PR DESCRIPTION
## Description
When message contains windows path "\" is interpret as single char to JSON encoder, which give me error
```
Invalid \escape: line 1 column 195 (char 194)
  File "D:\stable-diffusion-webui\installer.py", line 62, in emit
    self.buffer.append(json.loads(msg))
  File "D:\stable-diffusion-webui\webui.py", line 216, in start_common
    log.info(f'Using data path: {shared.cmd_opts.data_dir}')
  File "D:\stable-diffusion-webui\webui.py", line 301, in webui
    start_common()
  File "D:\stable-diffusion-webui\launch.py", line 144, in start_server
    server = server.webui(restart=not immediate)
  File "D:\stable-diffusion-webui\launch.py", line 189, in <module>
    instance = start_server(immediate=True, server=None)
json.decoder.JSONDecodeError: Invalid \escape: line 1 column 195 (char 194)
```

Inspecting value of `msg` in debugger shows:
`msg[194:] = '\\stable-diffusion-webui" }'`

This PR fixes this issue by replacing all '\\' with '\\\\'. 