### PR TITLE
Increase z-index for UI tooltip

### DIFF
--- a/javascript/style.css
+++ b/javascript/style.css
@@ -214,6 +214,7 @@ div#extras_scale_to_tab div.form{
   transition: opacity 0.2s ease-in;
   pointer-events: none;
   opacity: 0;
+  z-index: var(--layer-2);
 }
 
 .tooltip-show {


### PR DESCRIPTION
## Description

Small z-index overlap fix for tooltip UI being hidden under image preview.
## Notes

Written originally as issue in #1467 

## Environment and Testing

List the environment you have developed / tested this on
09:16:50-162046 INFO     Starting SD.Next
09:16:50-167556 INFO     Python 3.10.6 on Windows
09:16:50-211802 INFO     Version: b340e3f4 Sun Jun 18 16:30:59 2023 -0400
09:16:50-715615 INFO     nVidia CUDA toolkit detected
09:16:54-796057 INFO     Torch 2.0.1+cu118
09:16:54-844494 INFO     Torch backend: nVidia CUDA 11.8 cuDNN 8700
09:16:54-848953 INFO     Torch detected GPU: NVIDIA GeForce RTX 3080 VRAM 10240 Arch (8, 6) Cores 68