### PR TITLE
Add torch compile

### DIFF
--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -11,7 +11,6 @@ group.add_argument("--config", type=str, default=os.path.join(data_path, 'config
 group.add_argument("--ui-config", type=str, default=os.path.join(data_path, 'ui-config.json'), help="Use specific UI configuration file, default: %(default)s")
 group.add_argument("--medvram", action='store_true', help="Split model stages and keep only active part in VRAM, default: %(default)s")
 group.add_argument("--lowvram", action='store_true', help="Split model components and keep only active part in VRAM, default: %(default)s")
-group.add_argument("--torch_compile", action='store_true', help="Enable torch 2.0 compilation for UNet.")
 group.add_argument("--ckpt", type=str, default=None, help="Path to model checkpoint to load immediately, default: %(default)s")
 group.add_argument('--vae', type=str, default=None, help='Path to VAE checkpoint to load immediately, default: %(default)s')
 group.add_argument("--data-dir", type=str, default=os.path.dirname(os.path.dirname(os.path.realpath(__file__))), help="Base path where all user data is stored, default: %(default)s")

--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -11,6 +11,7 @@ group.add_argument("--config", type=str, default=os.path.join(data_path, 'config
 group.add_argument("--ui-config", type=str, default=os.path.join(data_path, 'ui-config.json'), help="Use specific UI configuration file, default: %(default)s")
 group.add_argument("--medvram", action='store_true', help="Split model stages and keep only active part in VRAM, default: %(default)s")
 group.add_argument("--lowvram", action='store_true', help="Split model components and keep only active part in VRAM, default: %(default)s")
+group.add_argument("--torch_compile", action='store_true', help="Enable torch 2.0 compilation for UNet.")
 group.add_argument("--ckpt", type=str, default=None, help="Path to model checkpoint to load immediately, default: %(default)s")
 group.add_argument('--vae', type=str, default=None, help='Path to VAE checkpoint to load immediately, default: %(default)s')
 group.add_argument("--data-dir", type=str, default=os.path.dirname(os.path.dirname(os.path.realpath(__file__))), help="Base path where all user data is stored, default: %(default)s")

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -521,7 +521,8 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
             if k == 'sd_vae':
                 sd_vae.reload_vae_weights()
 
-        sd_models.apply_token_merging(p.sd_model, p.get_token_merging_ratio())
+        if not cmd_opts.torch_compile:
+            sd_models.apply_token_merging(p.sd_model, p.get_token_merging_ratio())
 
         if cmd_opts.profile:
             """
@@ -539,7 +540,8 @@ def process_images(p: StableDiffusionProcessing) -> Processed:
         else:
             res = process_images_inner(p)
     finally:
-        sd_models.apply_token_merging(p.sd_model, 0)
+        if not cmd_opts.torch_compile:
+            sd_models.apply_token_merging(p.sd_model, 0)
         if p.override_settings_restore_afterwards: # restore opts to original state
             for k, v in stored_opts.items():
                 setattr(opts, k, v)

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -509,7 +509,7 @@ def load_diffuser(checkpoint_info=None, already_loaded_state_dict=None, timer=No
             sd_model.enable_sequential_cpu_offload()
         if shared.opts.cross_attention_optimization == "xFormers":
             sd_model.enable_xformers_memory_efficient_attention()
-        if shared.cmd_opts.torch_compile:
+        if shared.opts.cuda_compile:
             if not torch.cuda.is_available():
                 raise ValueError("Cannot use `torch.compile` if CUDA is not available.")
 

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -509,6 +509,18 @@ def load_diffuser(checkpoint_info=None, already_loaded_state_dict=None, timer=No
             sd_model.enable_sequential_cpu_offload()
         if shared.opts.cross_attention_optimization == "xFormers":
             sd_model.enable_xformers_memory_efficient_attention()
+        if shared.cmd_opts.torch_compile:
+            if not torch.cuda.is_available():
+                raise ValueError("Cannot use `torch.compile` if CUDA is not available.")
+
+            sd_model.to("cuda")
+            sd_model.unet.to(memory_format=torch.channels_last)
+            sd_model.unet = torch.compile(sd_model.unet, mode="reduce-overhead", fullgraph=True)
+
+            print(f"Compiling {sd_model.__class__.__name__} for default shape {8 * sd_model.unet.config.sample_size}. This might take up to a minute...")
+            sd_model("dummy prompt")
+            print("Complilation done.")
+
         sd_model.sd_checkpoint_info = checkpoint_info
         sd_model.sd_model_checkpoint = checkpoint_info.filename
         sd_model.sd_model_hash = checkpoint_info.hash


### PR DESCRIPTION
This PR adds `torch.compile` for the diffusers backend. 

Torch compile gives a 40% speed-up.

When adding `--torch_compile` to the command args, I'm getting:
```
100%|█████████████████████████████████████████████████████████████████████████████████| 20/20 [00:00<00:00, 42.01it/s]
```

compared to native Torch 2.0:
```
100%|█████████████████████████████████████████████████████████████████████████████████| 20/20 [00:00<00:00, 30.16it/s]
```

I'm running on:

```
device: NVIDIA GeForce RTX 4090 (2) (sm_90) (8, 9)
cuda: 11.8
cudnn: 8700
```

We've done a lot of benchmarks with `diffusers` and have torch.compile support for almost all important models:
https://huggingface.co/docs/diffusers/optimization/torch2.0