### PR TITLE
Extension Install Error Fix

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -444,7 +444,7 @@ def install_repositories():
 
 # run extension installer
 def run_extension_installer(folder):
-    path_installer = os.path.join(folder, "install.py")
+    path_installer = os.path.realpath(os.path.join(folder, "install.py"))
     if not os.path.isfile(path_installer):
         return
     try:


### PR DESCRIPTION
Extensions which have a install.py fail to install if we use a separate data directory and provide relative path like "--data-dir=../../SD-Data". Using realpath method to absolute path of installation script fixes the issue.

## Description

A clear and concise description of what you're trying to accomplish with this, so your intent doesn't have to be extracted from your code

Fixing extension install error

## Notes

More technical discussion about your changes go here, plus anything that a maintainer might have to specifically take a look at, or be wary of

I run webui with command: `./webui.sh --data-dir=../../SD-Data/`

I was getting this type of error with all extensions which have install.py.

```text
2023-06-22 21:11:45,722 | sd | ERROR | installer | Error running extension installer: ../../SD-Data/extensions/sd-webui-segment-anything/install.py
2023-06-22 21:11:45,724 | sd | DEBUG | installer | 
/bin/python3.10: can't open file '/Files/AI/Stable-Diffusion/SD-Data/extensions/sd-webui-segment-anything/../../SD-Data/extensions/sd-webui-segment-anything/install.py': [Errno 2] No such file or directory
```
This commit fixes the issue.

## Environment and Testing

List the environment you have developed / tested this on

ArchLinux with cuda 12.1
