### PR TITLE
[IPEX] Support SDE samplers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # defaults
 __pycache__
 .ruff_cache
+.vscode
 /cache.json
 /metadata.json
 /config.json

--- a/modules/devices.py
+++ b/modules/devices.py
@@ -206,6 +206,9 @@ if backend == 'ipex':
         args[4].to("cpu") if args[4] is not None else args[4],
         args[5], args[6], args[7], args[8]).to(get_cuda_device_string()),
         lambda *args, **kwargs: args[1].device != torch.device("cpu"))
+    CondFunc('torchsde._brownian.brownian_interval._randn',
+        lambda _, size, dtype, device, seed: torch.randn(size, dtype=dtype, device=device, generator=torch.xpu.Generator(device).manual_seed(int(seed))),
+        lambda _, size, dtype, device, seed: device != torch.device("cpu"))
 
 cpu = torch.device("cpu")
 device = device_interrogate = device_gfpgan = device_esrgan = device_codeformer = None

--- a/modules/sd_samplers_kdiffusion.py
+++ b/modules/sd_samplers_kdiffusion.py
@@ -326,14 +326,7 @@ class KDiffusionSampler:
         sigma_max = sigmas.max()
 
         current_iter_seeds = p.all_seeds[p.iteration * p.batch_size:(p.iteration + 1) * p.batch_size]
-        if devices.backend == 'ipex': #Remove this after Intel adds support for torch.Generator()
-            try:
-                return BrownianTreeNoiseSampler(x.to("cpu"), sigma_min, sigma_max, seed=current_iter_seeds, transform=lambda x: x.to("cpu"), transform_last=lambda x: x.to(shared.device)) # pylint: disable=E1123
-            except Exception:
-                shared.log.error("Please apply this patch to repositories/k-diffusion/k_diffusion/sampling.py: https://github.com/crowsonkb/k-diffusion/pull/68/files")
-                return None
-        else:
-            return BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=current_iter_seeds)
+        return BrownianTreeNoiseSampler(x, sigma_min, sigma_max, seed=current_iter_seeds)
 
     def sample_img2img(self, p, x, noise, conditioning, unconditional_conditioning, steps=None, image_conditioning=None):
         steps, t_enc = sd_samplers_common.setup_img2img_steps(p, steps)


### PR DESCRIPTION
## Description

This is a W/A since `torch.Generator()` API doesn't support `xpu` backend at the moment. So replacing it with `torch.xpu.Generator()` API provided by IPEX.

## Notes

Original error message for IPEX, when `DPM++ 2M SDE` or `DPM++ 2M SDE Karras` sampler is used:
```txt
08:08:02-165066 ERROR    Please apply this patch to repositories/k-diffusion/k_diffusion/sampling.py:
                         https://github.com/crowsonkb/k-diffusion/pull/68/files
08:08:02-241772 ERROR    Exception: Device type XPU is not supported for torch.Generator() api.
08:08:02-243317 ERROR    Arguments: args=('task(vf0n135fwtjw20x)', 'iron man', '', [], 20, 1, False, False, 1, 1, 6, 1,
                         -1.0, -1.0, 0, 0, 0, False, 512, 512, False, 0.7, 2, 'Latent', 0, 0, 0, [], 0, False,
                         'MultiDiffusion', False, True, 1024, 1024, 96, 96, 48, 4, 'None', 2, False, 10, 1, 1, 64,
                         False, False, False, False, False, 0.4, 0.4, 0.2, 0.2, '', '', 'Background', 0.2, -1.0, False,
                         0.4, 0.4, 0.2, 0.2, '', '', 'Background', 0.2, -1.0, False, 0.4, 0.4, 0.2, 0.2, '', '',
                         'Background', 0.2, -1.0, False, 0.4, 0.4, 0.2, 0.2, '', '', 'Background', 0.2, -1.0, False,
                         0.4, 0.4, 0.2, 0.2, '', '', 'Background', 0.2, -1.0, False, 0.4, 0.4, 0.2, 0.2, '', '',
                         'Background', 0.2, -1.0, False, 0.4, 0.4, 0.2, 0.2, '', '', 'Background', 0.2, -1.0, False,
                         0.4, 0.4, 0.2, 0.2, '', '', 'Background', 0.2, -1.0, False, 512, 64, True, True, True, False,
                         False, 7, 100, 'Constant', 0, 'Constant', 0, 4,
                         <scripts.controlnet_ui.controlnet_ui_group.UiControlNetUnit object at 0x7fe29c1aedd0>,
                         <scripts.controlnet_ui.controlnet_ui_group.UiControlNetUnit object at 0x7fe29c1ae920>,
                         <scripts.controlnet_ui.controlnet_ui_group.UiControlNetUnit object at 0x7fe3d3c02350>, False,
                         False, 'positive', 'comma', 0, False, False, '', 0, '', [], 0, '', [], 0, '', [], True, False,
                         False, False, 0, False, None, None, False, None, None, False, None, None, False, 50) kwargs={}
08:08:02-247736 ERROR    gradio call: RuntimeError
╭───────────────────────────────────────── Traceback (most recent call last) ──────────────────────────────────────────╮
│ /sd-webui/modules/call_queue.py:34 in f                                                                              │
│                                                                                                                      │
│    33 │   │   │   try:                                                                                               │
│ ❱  34 │   │   │   │   res = func(*args, **kwargs)                                                                    │
│    35 │   │   │   │   progress.record_results(id_task, res)                                                          │
│                                                                                                                      │
│ /sd-webui/modules/txt2img.py:56 in txt2img                                                                           │
│                                                                                                                      │
│   55 │   if processed is None:                                                                                       │
│ ❱ 56 │   │   processed = processing.process_images(p)                                                                │
│   57 │   p.close()                                                                                                   │
│                                                                                                                      │
│                                               ... 14 frames hidden ...                                               │
│                                                                                                                      │
│ /deps/venv/lib/python3.10/site-packages/torchsde/_brownian/brownian_interval.py:234 in _randn                        │
│                                                                                                                      │
│   233 │   │   size = self._top._size                                                                                 │
│ ❱ 234 │   │   return _randn(size, self._top._dtype, self._top._device, seed)                                         │
│   235                                                                                                                │
│                                                                                                                      │
│ /deps/venv/lib/python3.10/site-packages/torchsde/_brownian/brownian_interval.py:32 in _randn                         │
│                                                                                                                      │
│    31 def _randn(size, dtype, device, seed):                                                                         │
│ ❱  32 │   generator = torch.Generator(device).manual_seed(int(seed))                                                 │
│    33 │   return torch.randn(size, dtype=dtype, device=device, generator=generator)                                  │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
RuntimeError: Device type XPU is not supported for torch.Generator() api.
```

After this fix, the `SDE` samplers can be used for IPEX without manually applying the local patch for `k_diffusion`. However, the performance seems to be the same as that of `k_diffusion` patch: https://github.com/crowsonkb/k-diffusion/pull/68

## Environment and Testing

OS: Windows 11
Docker: [nuullll/ipex-arc-sd:v0.2](https://hub.docker.com/r/nuullll/ipex-arc-sd/tags) (oneAPI 2023.1)
```
arch: x86_64
cpu: x86_64
system: Linux
release: 5.15.90.1-microsoft-standard-WSL2
python: 3.10.6
torch: 1.13.0a0+gitb1dde16 Autocast  half
device: Intel(R) Graphics [0x56a0] (1)  # Arc A770
ipex: 1.13.120+xpu
```

- DPM++ 2M SDE: ~5.9 it/s
![image](https://github.com/vladmandic/automatic/assets/7253534/3ee0b2b7-02ea-46b6-8d80-8c54520ce85b)

- DPM++ 2M SDE Karras: ~5.9it/s
![image](https://github.com/vladmandic/automatic/assets/7253534/018c9b10-2a01-4e2f-bd78-14031a53363e)

