### PR TITLE
Fix cuda_compile, log_level does not exist

### DIFF
--- a/modules/sd_hijack.py
+++ b/modules/sd_hijack.py
@@ -183,7 +183,8 @@ class StableDiffusionModelHijack:
             try:
                 import logging
                 import torch._dynamo as dynamo # pylint: disable=unused-import
-                torch._dynamo.config.log_level = logging.WARNING if opts.cuda_compile_verbose else logging.CRITICAL # pylint: disable=protected-access
+                log_level = logging.WARNING if opts.cuda_compile_verbose else logging.CRITICAL # pylint: disable=protected-access
+                torch._logging.set_logs(dynamo=log_level, aot=log_level, inductor=log_level) # pylint: disable=protected-access
                 torch._dynamo.config.verbose = opts.cuda_compile_verbose # pylint: disable=protected-access
                 torch._dynamo.config.suppress_errors = opts.cuda_compile_errors # pylint: disable=protected-access
                 torch.backends.cudnn.benchmark = True


### PR DESCRIPTION
`torch._dynamo.config.log_level` was removed. It was replaced by torch._logging.

CUDA compile still doesn't work for me, but this makes it actually try.
