### PR TITLE
Fix gradio dropdown capturing clicks during and after fadeout

### DIFF
--- a/javascript/style.css
+++ b/javascript/style.css
@@ -549,3 +549,8 @@ div.controlnet_main_options { display: grid; grid-template-columns: 1fr 1fr; gri
 }
 .log-monitor td, .log-monitor th { padding-left: 1em; }
 .logo { background-image: url("logo.png") !important; background-repeat: no-repeat !important; background-position: center !important; background-size: contain !important; }
+
+/* Workaround for Gradio dropdowns capturing clicks during and after fadeout */
+.gradio-dropdown > label > div > :not(.showOptions) ~ ul.options {
+  pointer-events: none;
+}


### PR DESCRIPTION
## Description

Prevents clicks on Gradio dropdown list after it has started to fade out,

## Notes

The Gradio dropdown is transparent but still captures clicks for over 200ms after the initial click, resulting in miss-clicks.

