### PR TITLE
MPS fix

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -558,7 +558,7 @@ class PriorPipeline:
     def __call__(self, *args, **kwargs):
         unclip_outputs = self.prior(prompt=kwargs.get("prompt"), negative_prompt=kwargs.get("negative_prompt"))
 
-        if self.prior.device.type == "cuda" or self.prior.device.type == "xpu":
+        if self.prior.device.type == "cuda" or self.prior.device.type == "xpu" or self.prior.device.type == "mps":
             prior_device = self.prior.device
             self.prior.to("cpu")
             self.main.to(prior_device)
@@ -566,7 +566,7 @@ class PriorPipeline:
         kwargs = {**kwargs, **unclip_outputs}
         result = self.main(*args, **kwargs)
 
-        if self.main.device.type == "cuda" or self.main.device.type == "xpu":
+        if self.main.device.type == "cuda" or self.main.device.type == "xpu" or self.prior.device.type == "mps":
             main_device = self.main.device
             self.main.to("cpu")
             self.prior.to(main_device)


### PR DESCRIPTION
## Description

As described in the Discord thread (https://discord.com/channels/1101998836328697867/1129163429429641367), I added a simple fix for the error "LayerNormKernelImpl not implemented for 'Half'" on MPS devices when running the Kandinsky models. This just allows MPS to cast to CPU and back to the device.

## Notes

## Environment and Testing

Apple M1 Pro (16GB) running Ventura Version 13.4 (22F66)