### PR TITLE
Fix regression introduced by 02eac9f

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -443,6 +443,7 @@ def fix_seed(p):
 def create_infotext(p: StableDiffusionProcessing, all_prompts, all_seeds, all_subseeds, comments=None, iteration=0, position_in_batch=0): # pylint: disable=unused-argument
     index = position_in_batch + iteration * p.batch_size
 
+    enable_hr = getattr(p, 'enable_hr', False)
     token_merging_ratio = p.get_token_merging_ratio()
     token_merging_ratio_hr = p.get_token_merging_ratio(for_hr=True)
     uses_ensd = opts.eta_noise_seed_delta != 0
@@ -472,7 +473,7 @@ def create_infotext(p: StableDiffusionProcessing, all_prompts, all_seeds, all_su
         "Init image hash": getattr(p, 'init_img_hash', None),
         "Version": git_commit,
         "Token merging ratio": None if token_merging_ratio == 0 else token_merging_ratio,
-        "Token merging ratio hr": None if not p.enable_hr or token_merging_ratio_hr == 0 else token_merging_ratio_hr,
+        "Token merging ratio hr": None if not enable_hr or token_merging_ratio_hr == 0 else token_merging_ratio_hr,
         "Parser": opts.prompt_attention,
     }
     generation_params.update(p.extra_generation_params)


### PR DESCRIPTION
## Description

img2img processing pipelines do not use `enable_hr` as they don't use the hires fix, obviously.

The mentioned commit however assumes the pipeline possesses the attribute unconditionally, and every time the info text is created by an img2img pipeline it fails as it's not there.

This patch restores the previous behavior by using a local variable and `getattr` instead.

Fixes #1693.

## Environment and Testing

Linux, openSUSE Tumbleweed and Ubuntu 20.04. Tested with ControlNet and ADetailer, which would break after the first generation (the first time infotext would get written) without this change. 
