### PR TITLE
Search for models via the model file's basename

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -606,7 +606,8 @@ def load_diffuser(checkpoint_info=None, already_loaded_state_dict=None, timer=No
     try:
         devices.set_cuda_params()
         if shared.cmd_opts.ckpt is not None and model_data.initial: # initial load
-            model_name = modelloader.find_diffuser(shared.cmd_opts.ckpt)
+            ckpt_basename = os.path.basename(shared.cmd_opts.ckpt)
+            model_name = modelloader.find_diffuser(ckpt_basename)
             if model_name is not None:
                 shared.log.info(f'Loading diffuser {op}: {model_name}')
                 model_file = modelloader.download_diffusers_model(hub_id=model_name)


### PR DESCRIPTION
When searching for model info from the checkpoint specified from ckpt command line argument, strip the path from the argument so that we only search for the model's filename.

## Description

When I specified the model via `--ckpt`, the HF search failed with a 403, possibly because my checkpoint was at `../Models/blahblah/etc.safetensors`.  After fooling around with the failing search URL, I _think_ it's because of the initial `..`.  That perhaps was triggering some security mechanism.

Easiest way to fix this is to only search for the model file's basename, which is what we'd want to do anyway.


## Notes

The pretty-printed stack trace dumped by the error:

```
18:23:32-062762 ERROR    Failed to load diffusers model                                                                 
18:23:32-063920 ERROR    loading Diffusers model: HfHubHTTPError                                                        
╭───────────────────────────────────────── Traceback (most recent call last) ──────────────────────────────────────────╮
│ /home/steven/Development/automatic/venv/lib64/python3.11/site-packages/huggingface_hub/utils/_errors.py:261 in       │
│ hf_raise_for_status                                                                                                  │
│                                                                                                                      │
│   260 │   try:                                                                                                       │
│ ❱ 261 │   │   response.raise_for_status()                                                                            │
│   262 │   except HTTPError as e:                                                                                     │
│                                                                                                                      │
│ /home/steven/Development/automatic/venv/lib64/python3.11/site-packages/requests/models.py:1021 in raise_for_status   │
│                                                                                                                      │
│   1020 │   │   if http_error_msg:                                                                                    │
│ ❱ 1021 │   │   │   raise HTTPError(http_error_msg, response=self)                                                    │
│   1022                                                                                                               │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
HTTPError: 403 Client Error: Forbidden for url: 
https://huggingface.co/api/models?search=..%2FModels%2FStable-diffusion%2Fsdxl_base_pruned_no-ema.safetensors&filter=tex
t-to-image&filter=diffusers&full=True&sort=downloads&direction=-1&limit=5

The above exception was the direct cause of the following exception:

╭───────────────────────────────────────── Traceback (most recent call last) ──────────────────────────────────────────╮
│ /home/steven/Development/automatic/modules/sd_models.py:609 in load_diffuser                                         │
│                                                                                                                      │
│    608 │   │   if shared.cmd_opts.ckpt is not None and model_data.initial: # initial load                            │
│ ❱  609 │   │   │   model_name = modelloader.find_diffuser(shared.cmd_opts.ckpt)                                      │
│    610 │   │   │   if model_name is not None:                                                                        │
│                                                                                                                      │
│ /home/steven/Development/automatic/modules/modelloader.py:90 in find_diffuser                                        │
│                                                                                                                      │
│    89 │   )                                                                                                          │
│ ❱  90 │   models = list(api.list_models(filter=filt, full=True, limit=5, sort="downloads", dir                       │
│    91 │   shared.log.debug(f'Searching diffusers models: {name} {len(models) > 0}')                                  │
│                                                                                                                      │
│                                               ... 1 frames hidden ...                                                │
│                                                                                                                      │
│ /home/steven/Development/automatic/venv/lib64/python3.11/site-packages/huggingface_hub/utils/_pagination.py:36 in    │
│ paginate                                                                                                             │
│                                                                                                                      │
│   35 │   r = session.get(path, params=params, headers=headers)                                                       │
│ ❱ 36 │   hf_raise_for_status(r)                                                                                      │
│   37 │   yield from r.json()                                                                                         │
│                                                                                                                      │
│ /home/steven/Development/automatic/venv/lib64/python3.11/site-packages/huggingface_hub/utils/_errors.py:303 in       │
│ hf_raise_for_status                                                                                                  │
│                                                                                                                      │
│   302 │   │   # as well (request id and/or server error message)                                                     │
│ ❱ 303 │   │   raise HfHubHTTPError(str(e), response=response) from e                                                 │
│   304                                                                                                                │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
HfHubHTTPError: 403 Client Error: Forbidden for url: 
https://huggingface.co/api/models?search=..%2FModels%2Fblahblah%2Fmy-model-name.safetensors&filter=text-to-image&filter=diffusers&full=True&sort=downloads&direction=-1&limit=5
```


That is, the 403'ing URL was:
https://huggingface.co/api/models?search=..%2FModels%2Fblahblah%2Fmy-model-name.safetensors&filter=text-to-image&filter=diffusers&full=True&sort=downloads&direction=-1&limit=5

This PR would instead succeed with the following:
https://huggingface.co/api/models?search=my-model-name.safetensors&filter=text-to-image&filter=diffusers&full=True&sort=downloads&direction=-1&limit=5



## Environment and Testing

openSUSE Tumbleweed with a Radeon RX 6800
