### PR TITLE
Disable hold-to-preview

### DIFF
--- a/javascript/imageViewer.js
+++ b/javascript/imageViewer.js
@@ -91,7 +91,7 @@ function setupImageForLightbox(e) {
   e.dataset.modded = true;
   e.style.cursor = 'pointer';
   e.style.userSelect = 'none';
-  e.addEventListener('mousedown', (evt) => {
+  e.addEventListener('click', (evt) => {
     if (evt.button !== 0) return;
     const initialZoom = (localStorage.getItem('modalZoom') || true) === 'yes';
     modalZoomSet(gradioApp().getElementById('modalImage'), initialZoom);

--- a/javascript/imageViewer.js
+++ b/javascript/imageViewer.js
@@ -1,12 +1,10 @@
 // A full size 'lightbox' preview modal shown when left clicking on gallery previews
-let previewTimestamp = Date.now();
 let previewDrag = false;
 let modalPreviewZone;
 
 function closeModal(force = false) {
   if (force) gradioApp().getElementById('lightboxModal').style.display = 'none';
   if (previewDrag) return;
-  if ((Date.now() - previewTimestamp) < 250) return;
   gradioApp().getElementById('lightboxModal').style.display = 'none';
 }
 
@@ -64,7 +62,6 @@ function showModal(event) {
   if (modalImage.style.display === 'none') lb.style.setProperty('background-image', `url(${source.src})`);
   lb.style.display = 'flex';
   lb.onkeydown = modalKeyHandler;
-  previewTimestamp = Date.now();
   event.stopPropagation();
 }
 


### PR DESCRIPTION
## Description

Allows for drag'n'drop of images.

A clear and concise description of what you're trying to accomplish with this, so your intent doesn't have to be extracted from your code


## Environment and Testing

Tested in the ImageBrowser panel.