### PR TITLE
Ignore localizations folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ venv
 /log
 /cert
 .vscode/
+/localizations
 
 # unexcluded so folders get created
 !/repositories/.placeholder


### PR DESCRIPTION
Users may create the `localizations` folder to enable localization extensions. Ignore it so that `--upgrade` won't remove the `localizations` folder unexpectedly.

Tested with https://github.com/journey-ad/sd-webui-bilingual-localization:

![image](https://github.com/vladmandic/automatic/assets/7253534/7a7ffd4d-108e-4d0e-acf2-6f4c274f04cd)

