### PR TITLE
Fix Image Viewer opening when used in multiple tabs

### DIFF
--- a/javascript/imageViewer.js
+++ b/javascript/imageViewer.js
@@ -123,12 +123,15 @@ function galleryClickEventHandler(event) {
 }
 
 function initImageViewer() {
-  const galleryPreview = gradioApp().querySelector('.gradio-gallery > div.preview');
-  if (galleryPreview) {
-    const fullImgPreview = galleryPreview.querySelectorAll('img');
-    if (fullImgPreview.length > 0) {
-      galleryPreview.addEventListener('click', galleryClickEventHandler, true);
-      fullImgPreview.forEach(setupImageForLightbox);
+  // Each tab has its own gradio-gallery
+  const galleryPreviews = gradioApp().querySelectorAll('.gradio-gallery > div.preview');
+  if (galleryPreviews.length > 0) {
+    for (const galleryPreview of galleryPreviews) {
+      const fullImgPreview = galleryPreview.querySelectorAll('img');
+      if (fullImgPreview.length > 0) {
+        galleryPreview.addEventListener('click', galleryClickEventHandler, true);
+        fullImgPreview.forEach(setupImageForLightbox);
+      }
     }
   }
   if (imageViewerInitialized) return;


### PR DESCRIPTION
## Description

Fix that Image Viewer works only for the first used tab.

## Notes

Fixes https://github.com/vladmandic/automatic/issues/1803

## Environment and Testing

Firefox 115.0.2
