### PR TITLE
opencv-headless

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ lmdb
 lpips
 omegaconf
 open-clip-torch
-opencv-contrib-python
+opencv-contrib-python-headless
 piexif
 psutil
 pyyaml
@@ -48,7 +48,7 @@ antlr4-python3-runtime==4.9.3
 requests==2.31.0
 tqdm==4.65.0
 accelerate==0.20.3
-opencv-python==4.7.0.72
+opencv-python-headless==4.7.0.72
 diffusers==0.19.3
 einops==0.4.1
 gradio==3.32.0


### PR DESCRIPTION
## Description

This replaces both opencv-python pip packages with their respective headless variant, to remove dependency on Qt/X11 libs.

## Notes

Ref #1933

## Environment and Testing

Tested on Sagemaker Studio