### PR TITLE
Improved ROCm installer for Navi 3x and ROCm 5.5+ (and experimental Navi 2x support)

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -314,9 +314,49 @@ def check_torch():
         xformers_package = os.environ.get('XFORMERS_PACKAGE', 'xformers==0.0.20' if opts.get('cross_attention_optimization', '') == 'xFormers' else 'none')
     elif allow_rocm and (shutil.which('rocminfo') is not None or os.path.exists('/opt/rocm/bin/rocminfo') or os.path.exists('/dev/kfd')):
         log.info('AMD ROCm toolkit detected')
+
+        command = subprocess.run('rocm_agent_enumerator | grep -v gfx000', shell=True, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        amd_gpus = command.stdout.decode(encoding="utf8", errors="ignore").split('\n')
+        amd_gpus = [x for x in amd_gpus if x]
+        log.debug(f'ROCm agents detected: {amd_gpus}')
+
+        # use the first available amd gpu by default
+        hip_visible_devices = []
+        for idx, gpu in enumerate(amd_gpus):
+            if gpu in ['gfx1100', 'gfx1101', 'gfx1102']:
+                hip_visible_devices.append((idx, gpu, 'navi3x'))
+                break
+            # experimental navi 2x support
+            if gpu in ['gfx1030', 'gfx1031', 'gfx1032', 'gfx1034']:
+                hip_visible_devices.append((idx, gpu, 'navi2x'))
+                break
+        if len(hip_visible_devices) > 0:
+            idx, gpu, arch = hip_visible_devices[0]
+            log.debug(f'ROCm agent used by default: idx={idx} gpu={gpu} arch={arch}')
+
+            os.environ.setdefault('HIP_VISIBLE_DEVICES', str(idx))
+            if arch == 'navi3x':
+                os.environ.setdefault('HSA_OVERRIDE_GFX_VERSION', '11.0.0')
+            elif arch == 'navi2x':
+                os.environ.setdefault('HSA_OVERRIDE_GFX_VERSION', '10.3.0')
+                # install tensorflow-rocm for navi2x
+                os.environ.setdefault('TENSORFLOW_PACKAGE', 'tensorflow-rocm')
+            else:
+                log.debug(f'HSA_OVERRIDE_GFX_VERSION auto config is skipped for {gpu}')
+
         os.environ.setdefault('PYTORCH_HIP_ALLOC_CONF', 'garbage_collection_threshold:0.8,max_split_size_mb:512')
-        os.environ.setdefault('TENSORFLOW_PACKAGE', 'tensorflow-rocm')
-        torch_command = os.environ.get('TORCH_COMMAND', 'torch==2.0.1 torchvision==0.15.2 --index-url https://download.pytorch.org/whl/rocm5.4.2')
+
+        command = subprocess.run('hipconfig --version', shell=True, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        major_ver, minor_ver, *_ = command.stdout.decode(encoding="utf8", errors="ignore").split('.')
+        rocm_ver = f'{major_ver}.{minor_ver}'
+        log.debug(f'ROCm version detected: {rocm_ver}')
+
+        if rocm_ver in ['5.5', '5.6']:
+            # install torch nightly via torchvision to avoid wasting bandwidth when torchvision depends on torch from yesterday
+            torch_command = os.environ.get('TORCH_COMMAND', f'torchvision --pre --index-url https://download.pytorch.org/whl/nightly/rocm{rocm_ver}')
+        else:
+            torch_command = os.environ.get('TORCH_COMMAND', 'torch==2.0.1 torchvision==0.15.2 --index-url https://download.pytorch.org/whl/rocm5.4.2')
+
         xformers_package = os.environ.get('XFORMERS_PACKAGE', 'none')
     elif allow_ipex and (args.use_ipex or shutil.which('sycl-ls') is not None or shutil.which('sycl-ls.exe') is not None or os.environ.get('ONEAPI_ROOT') is not None or os.path.exists('/opt/intel/oneapi') or os.path.exists("C:/Program Files (x86)/Intel/oneAPI") or os.path.exists("C:/oneAPI")):
         args.use_ipex = True # pylint: disable=attribute-defined-outside-init

--- a/installer.py
+++ b/installer.py
@@ -314,11 +314,17 @@ def check_torch():
         xformers_package = os.environ.get('XFORMERS_PACKAGE', 'xformers==0.0.20' if opts.get('cross_attention_optimization', '') == 'xFormers' else 'none')
     elif allow_rocm and (shutil.which('rocminfo') is not None or os.path.exists('/opt/rocm/bin/rocminfo') or os.path.exists('/dev/kfd')):
         log.info('AMD ROCm toolkit detected')
+        os.environ.setdefault('PYTORCH_HIP_ALLOC_CONF', 'garbage_collection_threshold:0.8,max_split_size_mb:512')
+        os.environ.setdefault('TENSORFLOW_PACKAGE', 'tensorflow-rocm')
 
-        command = subprocess.run('rocm_agent_enumerator | grep -v gfx000', shell=True, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        amd_gpus = command.stdout.decode(encoding="utf8", errors="ignore").split('\n')
-        amd_gpus = [x for x in amd_gpus if x]
-        log.debug(f'ROCm agents detected: {amd_gpus}')
+        try:
+            command = subprocess.run('rocm_agent_enumerator', shell=True, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            amd_gpus = command.stdout.decode(encoding="utf8", errors="ignore").split('\n')
+            amd_gpus = [x for x in amd_gpus if x and x != 'gfx000']
+            log.debug(f'ROCm agents detected: {amd_gpus}')
+        except Exception as e:
+            log.debug(f'Run rocm_agent_enumerator failed: {e}')
+            amd_gpus = []
 
         # use the first available amd gpu by default
         hip_visible_devices = []
@@ -337,19 +343,21 @@ def check_torch():
             os.environ.setdefault('HIP_VISIBLE_DEVICES', str(idx))
             if arch == 'navi3x':
                 os.environ.setdefault('HSA_OVERRIDE_GFX_VERSION', '11.0.0')
+                # do not use tensorflow-rocm for navi 3x
+                os.environ.setdefault('TENSORFLOW_PACKAGE', 'tensorflow==2.13.0')
             elif arch == 'navi2x':
                 os.environ.setdefault('HSA_OVERRIDE_GFX_VERSION', '10.3.0')
-                # install tensorflow-rocm for navi2x
-                os.environ.setdefault('TENSORFLOW_PACKAGE', 'tensorflow-rocm')
             else:
                 log.debug(f'HSA_OVERRIDE_GFX_VERSION auto config is skipped for {gpu}')
 
-        os.environ.setdefault('PYTORCH_HIP_ALLOC_CONF', 'garbage_collection_threshold:0.8,max_split_size_mb:512')
-
-        command = subprocess.run('hipconfig --version', shell=True, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        major_ver, minor_ver, *_ = command.stdout.decode(encoding="utf8", errors="ignore").split('.')
-        rocm_ver = f'{major_ver}.{minor_ver}'
-        log.debug(f'ROCm version detected: {rocm_ver}')
+        try:
+            command = subprocess.run('hipconfig --version', shell=True, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            major_ver, minor_ver, *_ = command.stdout.decode(encoding="utf8", errors="ignore").split('.')
+            rocm_ver = f'{major_ver}.{minor_ver}'
+            log.debug(f'ROCm version detected: {rocm_ver}')
+        except Exception as e:
+            log.debug(f'Run hipconfig failed: {e}')
+            rocm_ver = None
 
         if rocm_ver in ['5.5', '5.6']:
             # install torch nightly via torchvision to avoid wasting bandwidth when torchvision depends on torch from yesterday

--- a/installer.py
+++ b/installer.py
@@ -344,7 +344,8 @@ def check_torch():
             if arch == 'navi3x':
                 os.environ.setdefault('HSA_OVERRIDE_GFX_VERSION', '11.0.0')
                 # do not use tensorflow-rocm for navi 3x
-                os.environ.setdefault('TENSORFLOW_PACKAGE', 'tensorflow==2.13.0')
+                if os.environ.get('TENSORFLOW_PACKAGE') == 'tensorflow-rocm':
+                    os.environ['TENSORFLOW_PACKAGE'] = 'tensorflow==2.13.0'
             elif arch == 'navi2x':
                 os.environ.setdefault('HSA_OVERRIDE_GFX_VERSION', '10.3.0')
             else:

--- a/webui.py
+++ b/webui.py
@@ -18,11 +18,6 @@ local_url = None
 errors.log.debug('Loading Torch')
 import torch # pylint: disable=C0411
 try:
-    rnd = torch.sum(torch.randn(2, 2)).to(0)
-    errors.log.debug(f'Torch init: {rnd / rnd == 1.0}') # fix silly pytorch_lightning issue
-except Exception:
-    pass
-try:
     import intel_extension_for_pytorch as ipex # pylint: disable=import-error, unused-import
 except Exception:
     pass


### PR DESCRIPTION
## Description

This PR detects ROCm agents in `installer.py` and set up correct `HIP_VISIBLE_DEVICES` and `HSA_OVERRIDE_GFX_VERSION` environment variables, which should avoid issues caused by not setting up them correctly, enabling a smooth out-of-box experience for Navi 3x users.

This PR also disables the usage of `tensorflow-rocm` for Navi 3x because they aren't supported yet. Revert a previous change from https://github.com/vladmandic/automatic/issues/1929 as well.

Experimental support for Navi 2x is added too, but I haven't tested it.

## How does it work?

We will firstly find out all ROCm agents via `rocm_agent_enumerator`.

Use the first available Navi 3x/2x dGPU to set up `HIP_VISIBLE_DEVICES`, which makes the app see only one GPU that works, so that unsupported GPUs aren't used and will not be overrided incorrectly later, both of which might lead to some sort of core dump. `HIP_VISIBLE_DEVICES` is not set when no device matches our list, and can be overwritten by explicitly setting it.

Also, `HSA_OVERRIDE_GFX_VERSION` is automatically configured for Navi 3x/2x device if it is found in the previous step, to avoid HIP to incorrectly recognize our GPU, thus avoid another source of core dump. It won't be set if conditions fail to meet, and can be overwritten explicitly.

Then we read ROCm version from `hipconfig --version`. If it's ROCm 5.5+, the officially built `torch` nightly will be installed for best performance and compatibility. If not, fallback to the original behavior: use `torch` built for ROCm 5.4.2.

## Notes

AMD GPUs other than Navi 3x and Navi 2x are not considered in this PR, because they might just work. Let's add more in the future.

## Environment and Testing

Developed on Ubuntu 22.04, with ROCm 5.6 installed.

Hardware: 7800X3D (gfx1036) + RX 7900 XTX (gfx1100)

Tested in host environment and Docker environment with ROCm 5.6 installed.

There was an attempt https://github.com/vladmandic/automatic/pull/1972. @Aptronymist would you mind helping me test if this works on your end?

```bash
git clone https://github.com/are-we-gfx1100-yet/automatic/tree/merge/rocm_installer_for_navi
cd automatic
./webui.sh --debug
```