### PR TITLE
Fix training with up-to-date dependencies and add SD-XL LoRA training support

### DIFF
--- a/cli/options.py
+++ b/cli/options.py
@@ -112,7 +112,7 @@ lora = Map({
 process = Map({
     # general settings, do not modify
     'format': '.jpg', # image format
-    'target_size': 512, # target resolution
+    'target_size': 1024, # target resolution
     'segmentation_model': 0, # segmentation model 0/general 1/landscape
     'segmentation_background': (192, 192, 192), # segmentation background color
     'blur_score': 1.8, # max score for face blur detection

--- a/cli/options.py
+++ b/cli/options.py
@@ -90,7 +90,7 @@ lora = Map({
     "save_every_n_epochs": None,
     "save_last_n_epochs_state": None,
     "save_last_n_epochs": None,
-    "save_model_as": "ckpt",
+    "save_model_as": "safetensors",
     "save_n_epoch_ratio": None,
     "save_precision": "fp16",
     "save_state": False,

--- a/cli/options.py
+++ b/cli/options.py
@@ -106,6 +106,7 @@ lora = Map({
     "v2": False,
     "vae": None,
     "xformers": False,
+    "vae_batch_size": 1,
 })
 
 process = Map({

--- a/cli/train.py
+++ b/cli/train.py
@@ -376,7 +376,7 @@ def check_versions():
     error = False
     import accelerate
     if accelerate.__version__ != '0.20.3':
-        log.error(f'invalid accelerate version: accelerate=0.19.0 found={accelerate.__version__}')
+        log.error(f'invalid accelerate version: accelerate=0.20.3 found={accelerate.__version__}')
         error = True
     log.info('checking diffusers')
     import diffusers


### PR DESCRIPTION
## Description

Update submodule in `modules/lora` to the dev branch of https://github.com/kohya-ss/sd-scripts. So that we don't need to downgrade `diffusers` before training anymore.

Fix LoRA/LyCORIS training integration.

Add SD-XL LoRA training integration.

Save LoRAs as `safetensors` by default, to allow direct use in Diffusers.

Maybe we should add an argument for `process.target_size`.

## Notes

Please generate images with a resolution of 1024x1024 for best results in SD-XL.

## Environment and Testing

Developed on Ubuntu 22.04, with ROCm 5.6 installed.

Hardware: 7800X3D (gfx1036) + RX 7900 XTX (gfx1100)

Tested in host environment.
