### PR TITLE
Add a FS directory/path cacher

### DIFF
--- a/extensions-builtin/Lora/lora.py
+++ b/extensions-builtin/Lora/lora.py
@@ -3,6 +3,7 @@ import re
 from typing import Union
 import torch
 from modules import shared, devices, sd_models, errors, scripts, sd_hijack, hashes
+from modules.modelloader import filter_paths, directory_files, extension_filter
 
 metadata_tags_order = {"ss_sd_model_name": 1, "ss_resolution": 2, "ss_clip_skip": 3, "ss_num_train_images": 10, "ss_tag_frequency": 20}
 
@@ -444,10 +445,7 @@ def list_available_loras():
 
     os.makedirs(shared.cmd_opts.lora_dir, exist_ok=True)
 
-    candidates = list(shared.walk_files(shared.cmd_opts.lora_dir, allowed_extensions=[".pt", ".ckpt", ".safetensors"]))
-    for filename in sorted(candidates, key=str.lower):
-        if os.path.isdir(filename):
-            continue
+    for filename in sorted(filter_paths(directory_files(shared.cmd_opts.lora_dir), filter=extension_filter(['.PT', '.CKPT', '.SAFETENSORS'])), key=str.lower):
 
         name = os.path.splitext(os.path.basename(filename))[0]
         entry = LoraOnDisk(name, filename)

--- a/extensions-builtin/Lora/lora.py
+++ b/extensions-builtin/Lora/lora.py
@@ -3,7 +3,7 @@ import re
 from typing import Union
 import torch
 from modules import shared, devices, sd_models, errors, scripts, sd_hijack, hashes
-from modules.modelloader import filter_paths, directory_files, extension_filter
+from modules.modelloader import directory_files, extension_filter
 
 metadata_tags_order = {"ss_sd_model_name": 1, "ss_resolution": 2, "ss_clip_skip": 3, "ss_num_train_images": 10, "ss_tag_frequency": 20}
 
@@ -445,7 +445,7 @@ def list_available_loras():
 
     os.makedirs(shared.cmd_opts.lora_dir, exist_ok=True)
 
-    for filename in sorted(filter_paths(directory_files(shared.cmd_opts.lora_dir), filter=extension_filter(['.PT', '.CKPT', '.SAFETENSORS'])), key=str.lower):
+    for filename in sorted([*filter(extension_filter(['.PT', '.CKPT', '.SAFETENSORS']), directory_files(shared.cmd_opts.lora_dir))], key=str.lower):
 
         name = os.path.splitext(os.path.basename(filename))[0]
         entry = LoraOnDisk(name, filename)

--- a/modules/modelloader.py
+++ b/modules/modelloader.py
@@ -169,6 +169,9 @@ def directory_directories(dir:str, *, recursive:bool=True) -> dict[str,tuple[flo
                 break
     return directory_directories
 
+def directory_mtime(dir:str, *, recursive:bool=True) -> float:
+    return float(max(0, *[mtime for mtime, _ in directory_directories(dir, recursive=recursive).values()]))
+
 def directories_file_paths(directories:dict) -> list[str]:
     return sum([[fp for fp in dat[1]] for dat in directories.values()], [])
 
@@ -190,8 +193,12 @@ def directory_files(*directories:list[str], recursive:bool=True) -> list[str]:
     return unique_paths(sum([[fp for fp in directories_file_paths(directory_directories(dir, recursive=recursive))] for dir in unique_directories(directories, recursive=recursive)],[]))
 
 def extension_filter(ext_filter=None, ext_blacklist=None):
+    if ext_filter:
+        ext_filter = [ext.upper() for ext in ext_filter]
+    if ext_blacklist:
+        ext_blacklist = [ext.upper() for ext in ext_blacklist]
     def filter(fp:str):
-        return (not ext_filter or any(fp.endswith(ew) for ew in ext_filter)) and (not ext_blacklist or not any(fp.endswith(ew) for ew in ext_blacklist))
+        return (not ext_filter or any(fp.upper().endswith(ew) for ew in ext_filter)) and (not ext_blacklist or not any(fp.upper().endswith(ew) for ew in ext_blacklist))
     return filter
 
 def load_models(model_path: str, model_url: str = None, command_path: str = None, ext_filter=None, download_name=None, ext_blacklist=None) -> list:

--- a/modules/modelloader.py
+++ b/modules/modelloader.py
@@ -173,7 +173,7 @@ def directory_mtime(dir:str, *, recursive:bool=True) -> float:
     return float(max(0, *[mtime for mtime, _ in directory_directories(dir, recursive=recursive).values()]))
 
 def directories_file_paths(directories:dict) -> list[str]:
-    return sum([fp for fp in dat[1] for dat in directories.values()], [])
+    return sum(list([fp for fp in dat[1]] for dat in directories.values()), [])
 
 def filter_paths(paths:list[str], *, filter:callable=None) -> list[str]:
     return [fp for fp in paths if not (os.path.islink(fp) and not os.path.exists(fp)) and filter(fp)]
@@ -190,7 +190,7 @@ def unique_paths(paths:list[str]) -> list[str]:
     return { fp: True for fp in paths }.keys()
 
 def directory_files(*directories:list[str], recursive:bool=True) -> list[str]:
-    return unique_paths(sum([fp for fp in directories_file_paths(directory_directories(dir, recursive=recursive)) for dir in unique_directories(directories, recursive=recursive)],[]))
+    return unique_paths(sum(list([fp for fp in directories_file_paths(directory_directories(dir, recursive=recursive))] for dir in unique_directories(directories, recursive=recursive)),[]))
 
 def extension_filter(ext_filter=None, ext_blacklist=None):
     if ext_filter:

--- a/modules/modelloader.py
+++ b/modules/modelloader.py
@@ -173,7 +173,7 @@ def directory_mtime(dir:str, *, recursive:bool=True) -> float:
     return float(max(0, *[mtime for mtime, _ in directory_directories(dir, recursive=recursive).values()]))
 
 def directories_file_paths(directories:dict) -> list[str]:
-    return sum([[fp for fp in dat[1]] for dat in directories.values()], [])
+    return sum([fp for fp in dat[1] for dat in directories.values()], [])
 
 def filter_paths(paths:list[str], *, filter:callable=None) -> list[str]:
     return [fp for fp in paths if not (os.path.islink(fp) and not os.path.exists(fp)) and filter(fp)]
@@ -190,7 +190,7 @@ def unique_paths(paths:list[str]) -> list[str]:
     return { fp: True for fp in paths }.keys()
 
 def directory_files(*directories:list[str], recursive:bool=True) -> list[str]:
-    return unique_paths(sum([[fp for fp in directories_file_paths(directory_directories(dir, recursive=recursive))] for dir in unique_directories(directories, recursive=recursive)],[]))
+    return unique_paths(sum([fp for fp in directories_file_paths(directory_directories(dir, recursive=recursive)) for dir in unique_directories(directories, recursive=recursive)],[]))
 
 def extension_filter(ext_filter=None, ext_blacklist=None):
     if ext_filter:

--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -13,6 +13,7 @@ import modules.textual_inversion.dataset
 from modules.textual_inversion.learn_schedule import LearnRateScheduler
 from modules.textual_inversion.image_embedding import embedding_to_b64, embedding_from_b64, insert_image_data_embed, extract_image_data_embed, caption_image_overlay
 from modules.textual_inversion.logging import save_settings_to_file
+from modules.modelloader import filter_paths, directory_files, extension_filter, directory_mtime
 
 TextualInversionTemplate = namedtuple("TextualInversionTemplate", ["name", "path"])
 textual_inversion_templates = {}
@@ -85,15 +86,13 @@ class DirWithTextualInversionEmbeddings:
         if not os.path.isdir(self.path):
             return False
 
-        mt = os.path.getmtime(self.path)
-        if self.mtime is None or mt > self.mtime:
-            return True
+        return directory_mtime(self.path) != self.mtime
 
     def update(self):
         if not os.path.isdir(self.path):
             return
 
-        self.mtime = os.path.getmtime(self.path)
+        self.mtime = directory_mtime(self.path)
 
 
 class EmbeddingDatabase:
@@ -216,16 +215,19 @@ class EmbeddingDatabase:
     def load_from_dir(self, embdir):
         if not os.path.isdir(embdir.path):
             return
-        for root, _dirs, fns in os.walk(embdir.path, followlinks=True):
-            for fn in fns:
-                try:
-                    fullfn = os.path.join(root, fn)
-                    if os.stat(fullfn).st_size == 0:
-                        continue
-                    self.load_from_file(fullfn, fn)
-                except Exception as e:
-                    errors.display(e, f'embedding load {fn}')
+        
+        is_ext = extension_filter(['.PNG', '.WEBP', '.JXL', '.AVIF', '.BIN', '.PT', '.SAFETENSORS'])
+        is_not_preview = lambda fp: not next(iter(os.path.splitext(fp))).upper().endswith('.PREVIEW')
+
+        for file_path in filter_paths(directory_files(embdir.path), filter=lambda fp: is_ext(fp) and is_not_preview(fp)):
+            try:
+                if os.stat(file_path).st_size == 0:
                     continue
+                fn = os.path.basename(file_path)
+                self.load_from_file(file_path, fn)
+            except Exception as e:
+                errors.display(e, f'embedding load {fn}')
+                continue
 
     def load_textual_inversion_embeddings(self, force_reload=False):
         if not force_reload:

--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -13,7 +13,7 @@ import modules.textual_inversion.dataset
 from modules.textual_inversion.learn_schedule import LearnRateScheduler
 from modules.textual_inversion.image_embedding import embedding_to_b64, embedding_from_b64, insert_image_data_embed, extract_image_data_embed, caption_image_overlay
 from modules.textual_inversion.logging import save_settings_to_file
-from modules.modelloader import filter_paths, directory_files, extension_filter, directory_mtime
+from modules.modelloader import directory_files, extension_filter, directory_mtime
 
 TextualInversionTemplate = namedtuple("TextualInversionTemplate", ["name", "path"])
 textual_inversion_templates = {}
@@ -215,11 +215,11 @@ class EmbeddingDatabase:
     def load_from_dir(self, embdir):
         if not os.path.isdir(embdir.path):
             return
-        
+
         is_ext = extension_filter(['.PNG', '.WEBP', '.JXL', '.AVIF', '.BIN', '.PT', '.SAFETENSORS'])
         is_not_preview = lambda fp: not next(iter(os.path.splitext(fp))).upper().endswith('.PREVIEW')
 
-        for file_path in filter_paths(directory_files(embdir.path), filter=lambda fp: is_ext(fp) and is_not_preview(fp)):
+        for file_path in [*filter(lambda fp: is_ext(fp) and is_not_preview(fp), directory_files(embdir.path))]:
             try:
                 if os.stat(file_path).st_size == 0:
                     continue

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -193,11 +193,11 @@ class ExtraNetworksPage:
             htmls = []
             with Progress(
                 SpinnerColumn(),
-                TextColumn('[cyan]Creating Extra Network '+self.title+' HTML - {task.description}'), 
+                TextColumn('[cyan]Creating Extra Network '+self.title+' HTML - {task.description}'),
                 BarColumn(), TaskProgressColumn(), TextColumn('({task.completed}/{task.total})'),
                 TimeRemainingColumn(), TimeElapsedColumn(), transient=not shared.log.isEnabledFor(DEBUG), expand=True
             ) as progress:
-                task = progress.add_task(description=f'Initializing Items')
+                task = progress.add_task(description='Initializing Items')
                 items = self.items
                 progress.update(task, total=len(items))
                 __t = time()

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -34,7 +34,7 @@ def fetch_file(filename: str = ""):
         return FileResponse(filename, headers={"Accept-Ranges": "bytes"})
     if not any(Path(x).absolute() in Path(filename).absolute().parents for x in allowed_dirs):
         return JSONResponse({"error": f"File cannot be fetched: {filename}. Must be in one of directories registered by extra pages."})
-    if os.path.splitext(filename)[1].lower() not in (".png", ".jpg", ".webp"):
+    if os.path.splitext(filename)[1].lower() not in (".png", ".jpg", ".jpeg", ".webp"):
         return JSONResponse({"error": f"File cannot be fetched: {filename}. Only png and jpg and webp."})
     return FileResponse(filename, headers={"Accept-Ranges": "bytes"})
 

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -264,11 +264,11 @@ class ExtraNetworksPage:
         preview_extensions = ["jpg", "jpeg", "png", "webp", "tiff", "jp2"]
         dir = os.path.dirname(path)
         paths = modelloader.directory_directories(dir, recursive=False)
-        for file in sum([[f'{path}.thumb.{ext}'] for ext in preview_extensions], []): # use thumbnail if exists
-            if file in paths[dir][1]:
+        for file in [f'{path}.thumb.{ext}' for ext in preview_extensions]: # use thumbnail if exists
+            if file in paths[dir][1] and os.path.exists(file):
                 return self.link_preview(file)
-        for file in sum([[f'{path}.preview.{ext}', f'{path}.{ext}'] for ext in preview_extensions], []):
-            if file in paths[dir][1]:
+        for file in [f'{path}{mid}{ext}' for ext in preview_extensions for mid in ['.preview.', '.']]:
+            if file in paths[dir][1] and os.path.exists(file):
                 self.missing_thumbs.append(file)
                 return self.link_preview(file)
         return self.link_preview('html/card-no-preview.png')
@@ -363,6 +363,7 @@ def create_ui(container, button, tabname, skip_indexing = False):
         ui.description_target_filename = gr.Textbox('Description save filename', elem_id=tabname+"_description_filename", visible=False)
 
         for page in ui.stored_extra_pages:
+            shared.log.debug(f"Create UI Extra Network Page: {page.title}")
             page_html = page.create_html(ui.tabname, skip_indexing)
             with gr.Tab(page.title, id=page.title.lower().replace(" ", "_"), elem_classes="extra-networks-tab"):
                 page_elem = gr.HTML(page_html, elem_id=tabname+page.name+"_extra_page", elem_classes="extra-networks-page")
@@ -378,6 +379,7 @@ def create_ui(container, button, tabname, skip_indexing = False):
     button_close.click(fn=toggle_visibility, inputs=[state_visible], outputs=[state_visible, container])
 
     def refresh():
+        shared.log.debug("Refreshing UI Extra Networks Pages")
         res = []
         for pg in ui.stored_extra_pages:
             pg.html = ''

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -190,6 +190,7 @@ class ExtraNetworksPage:
                 self.items = []
                 shared.log.error(f'Extra networks error listing items: {self.__class__}')
             self.create_xyz_grid()
+            htmls = []
             with Progress(
                 SpinnerColumn(),
                 TextColumn('[cyan]Creating Extra Network '+self.title+' HTML - {task.description}'), 
@@ -199,16 +200,15 @@ class ExtraNetworksPage:
                 task = progress.add_task(description=f'Initializing Items')
                 items = self.items
                 progress.update(task, total=len(items))
-                __t = None
+                __t = time()
                 __i = 0
                 for item in items:
-                    if __t is None:
-                        __t = time()
                     __i += 1
                     self.metadata[item["name"]] = item.get("metadata", {})
                     self.info[item["name"]] = self.find_info(item['filename'])
-                    self.html += self.create_html_for_item(item, tabname)
+                    htmls.append(self.create_html_for_item(item, tabname))
                     progress.update(task, advance=1, description=f"{round(__i/(shared.time.time()-__t))} item/s")
+            self.html += ''.join(htmls)
             if len(subdirs_html) > 0 or len(self.html) > 0:
                 res = f"<div id='{tabname}_{self_name_id}_subdirs' class='extra-network-subdirs'>{subdirs_html}</div><div id='{tabname}_{self_name_id}_cards' class='extra-network-cards'>{self.html}</div>"
             else:


### PR DESCRIPTION
## Description

Related to and resolves Issue #1563 

- Added FS dir/path mechanism to 'modules.modelloader'
- Refactored 'modules.modelloader.load_models' to use the cache
- Refactored 'modules.ui_extra_networks.find_*' methods to use the cache
- Added progress indicator to 'modules.ui_extra_networks.create_html'

## Notes

The cache, as implemented, will always ensure it is up-to-date (per 'directory_has_changed') and significantly improves loading speed (when used with 'model_loader' and the 'find_*' methods) with large model directories.

## Environment and Testing

Overall load speed tested with ~10k models (mix of checkpoints, loras, lycoris, and embeddings) and ~40k secondary files (images, descriptions, CivitAI Info, etc).  Loading speeds went from ~1 hour and 45 minutes to ~5 minutes.

Confounding variable to loading speeds: this is over a fiber-attached storage device.  Connection is 10gbe full-duplex, remote source has an NVMe raid cache.  Saturation of the network is the norm, but laintency is a factor.  Regardless, small-scale local-storage testing also shows measurable improvements, so this should be a welcome addition.