### PR TITLE
Correcting legacy image optimization code

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -456,7 +456,7 @@ def atomically_save_image():
             pnginfo_data = PngImagePlugin.PngInfo()
             for k, v in params.pnginfo.items():
                 pnginfo_data.add_text(k, str(v))
-            image.save(fn, format=image_format, quality=shared.opts.jpeg_quality, pnginfo=pnginfo_data if shared.opts.image_metadata else None)
+            image.save(fn, format=image_format, optimize=True, compress_level=9, pnginfo=pnginfo_data if shared.opts.image_metadata else None)
         elif image_format == 'JPEG':
             if image.mode == 'RGBA':
                 shared.log.warning('Saving RGBA image as JPEG: Alpha channel will be lost')
@@ -464,7 +464,7 @@ def atomically_save_image():
             elif image.mode == 'I;16':
                 image = image.point(lambda p: p * 0.0038910505836576).convert("L")
             exif_bytes = piexif.dump({ "Exif": { piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(exifinfo, encoding="unicode") } })
-            image.save(fn, format=image_format, quality=shared.opts.jpeg_quality, exif=exif_bytes)
+            image.save(fn, format=image_format, optimize=True, quality=shared.opts.jpeg_quality, exif=exif_bytes)
         elif image_format == 'WEBP':
             if image.mode == 'I;16':
                 image = image.point(lambda p: p * 0.0038910505836576).convert("RGB")


### PR DESCRIPTION
Legacy A1111 code improperly implemented Pillow image optimization options, "quality=" never applied to PNG files (or anything else), only JPEG files, per [PNG docs](https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#png-saving) and [JPEG docs](https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#jpeg-saving)

This is now corrected, other than turning on the optimize=True, for backup and giggles, compress_level=9 is also set. For JPEG files, I also enabled optimize=True as it supposedly makes more optimized files.

## Environment and Testing

Tested it on my machine with no issues (other than forgetting to capitalize "true", which proved it was working by giving me an error and saying it should be "True". PNG files seem marginally smaller. Considering investigating other available methods to further reduce/optimize them. JPEGs also tested, no issues anywhere, this is the proper documented method.
