### PR TITLE
Change symbols so they display properly on macOS.

### DIFF
--- a/modules/ui_symbols.py
+++ b/modules/ui_symbols.py
@@ -1,11 +1,11 @@
 refresh = '⟲'
-close = '🗙'
+close = '✕'
 load = '⇧'
 save = '⇩'
 apply = '⇰'
 clear = '⊗'
 fill = '⊜'
-networks = '🗁'
+networks = '🌐'
 paste = '⇦'
 
 """


### PR DESCRIPTION
## Description
A few symbols won't display except as indecipherable boxes with hex codes on recent macOS versions. This fixes that by replacing those symbols with emoji, which should be available on most systems.
