### PR TITLE
Fix SDXL TI v2

### DIFF
--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -182,11 +182,12 @@ class EmbeddingDatabase:
                         for i in range(len(token_ids)):
                             clip_l.data[token_ids[i]] = embeddings_dict["clip_l"][i]
                     elif is_xl:
+                        pipe.tokenizer_2.add_tokens(tokens)
                         pipe.text_encoder.resize_token_embeddings(len(pipe.tokenizer))
                         pipe.text_encoder_2.resize_token_embeddings(len(pipe.tokenizer))
                         for i in range(len(token_ids)):
-                            clip_l.data[token_ids[i]] = embeddings_dict["clip_l"][i]
-                            clip_g.data[token_ids[i]] = embeddings_dict["clip_g"][i]
+                            pipe.text_encoder.get_input_embeddings().weight.data[token_ids[i]] = embeddings_dict["clip_l"][i]
+                            pipe.text_encoder_2.get_input_embeddings().weight.data[token_ids[i]] = embeddings_dict["clip_g"][i]
                     self.register_embedding(embedding, shared.sd_model)
                 else:
                     raise NotImplementedError


### PR DESCRIPTION
For some reason trying to resize `clip_l` and `clip_g` doesn't work resulting in this error `index 49408 is out of bounds for dimension 0 with size 49408`

`self.register_embedding` doesn't work for SDXL `'StableDiffusionXLPipeline' object has no attribute 'cond_stage_model'` but the exception happens after the embeddings are loaded so is inconsequential to function.

