### PR TITLE
Approximate Simple for SDXL

### DIFF
--- a/modules/sd_samplers_common.py
+++ b/modules/sd_samplers_common.py
@@ -33,8 +33,6 @@ def single_sample_to_image(sample, approximation=None):
             x_sample = x_sample[[2,1,0],:,:] # BGR to RGB
     elif approximation == 2:
         x_sample = sd_vae_approx.cheap_approximation(sample) * 0.5 + 0.5
-        if shared.sd_model_type == "sdxl":
-            x_sample = x_sample[[2,1,0],:,:] # BGR to RGB
     elif approximation == 3:
         # x_sample = sample * 1.5
         # x_sample = sd_vae_taesd.model()(x_sample.to(devices.device, devices.dtype).unsqueeze(0))[0].detach()


### PR DESCRIPTION
## Description

Adds a set of weights and biases for the Approximate Simple preview method, specifically for SDXL latents. Also transposes the existing SD coefficients to be compatible with nn.functional.conv2d

Before (SD weights + BGR to RGB), After, Target
![target](https://github.com/vladmandic/automatic/assets/43395286/56ef5665-6d0e-4acb-8d43-e57d9b9d9fa1)


## Notes

I dumped a set of latents and images with variations of the prompt "rainbow" and "colorful", then wrote a simple training loop to optimize the Conv2d parameters.

The previous values for SD do not have any bias values, and could see retraining with them to get a better result, the images still look rather crusty, but having a bias does do a lot to get the colors closer.

## Environment and Testing

Windows 11
NVidia RTX 3050
