### PR TITLE
Fix potential issues parsing extension repo URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ cache
 /log
 /cert
 .vscode/
+.idea/
 /localizations
 
 # unexcluded so folders get created

--- a/modules/ui_extensions.py
+++ b/modules/ui_extensions.py
@@ -318,9 +318,12 @@ def create_html(search_text, sort_column):
     stats = { 'processed': 0, 'enabled': 0, 'hidden': 0, 'installed': 0 }
     for ext in sorted(extensions_list, key=sort_function, reverse=sort_reverse):
         installed = get_installed(ext)
-        author = f"Author: {ext['url'].split('/')[3]}" if 'github' in ext['url'] else ''
+        author = ''
         try:
-            updated = datetime.timestamp(datetime.fromisoformat(ext.get('updated', '2000-01-01T00:00:00.000Z').rstrip('Z')))
+            if 'github' in ext_url:
+                author = ext_url.split('/')[-2].split(':')[-1] if '/' in ext_url else ext_url.split(':')[1].split('/')[0]
+                author = f"Author: {author}"
+                updated = datetime.timestamp(datetime.fromisoformat(ext.get('updated', '2000-01-01T00:00:00.000Z').rstrip('Z')))
         except Exception:
             updated = datetime.timestamp(datetime.now())
         update_available = (installed is not None) and (ext['remote'] is not None) and (ext['commit_date'] + 60 * 60 < updated)


### PR DESCRIPTION
If a repo URL has git@github... in it, the author parsing will fail and the app will crash.

## Description

Fixes this issue:

```
 /opt/rd/automatic/modules/ui_extensions.py:321 in create_html                                                                                   │
│                                                                                                                                                 │
│   320         installed = get_installed(ext)                                                                                                    │
│ ❱ 321         author = f"Author: {ext['url'].split('/')[3]}" if 'github' in ext['url'] else ''                                                  │
│   322         try:                                                                                                                              │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
IndexError: list index out of range

```

## Notes

Should be pretty straightforward.
Also, add .idea to the gitignore.

## Environment and Testing

Ubuntu 22, Windoze
