### PR TITLE
Feat/xyz sub grids

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -122,7 +122,7 @@ class GridAnnotation:
         self.size = None
 
 
-def draw_grid_annotations(im, width, height, hor_texts, ver_texts, margin=0):
+def draw_grid_annotations(im, width, height, hor_texts, ver_texts, margin=0, title=None):
     def wrap(drawing, text, font, line_length):
         lines = ['']
         for word in text.split():
@@ -163,7 +163,8 @@ def draw_grid_annotations(im, width, height, hor_texts, ver_texts, margin=0):
     assert rows == len(ver_texts), f'bad number of vertical texts: {len(ver_texts)}; must be {rows}'
     calc_img = Image.new("RGB", (1, 1), "white")
     calc_d = ImageDraw.Draw(calc_img)
-    for texts, allowed_width in zip(hor_texts + ver_texts, [width] * len(hor_texts) + [pad_left] * len(ver_texts)):
+    title_texts = [title] if title else [[GridAnnotation()]]
+    for texts, allowed_width in zip(hor_texts + ver_texts + title_texts, [width] * len(hor_texts) + [pad_left] * len(ver_texts) + [(width+margin)*cols]):
         items = [] + texts
         texts.clear()
         for line in items:
@@ -176,19 +177,27 @@ def draw_grid_annotations(im, width, height, hor_texts, ver_texts, margin=0):
     hor_text_heights = [sum([line.size[1] + line_spacing for line in lines]) - line_spacing for lines in hor_texts]
     ver_text_heights = [sum([line.size[1] + line_spacing for line in lines]) - line_spacing * len(lines) for lines in ver_texts]
     pad_top = 0 if sum(hor_text_heights) == 0 else max(hor_text_heights) + line_spacing * 2
-    result = Image.new("RGB", (im.width + pad_left + margin * (cols-1), im.height + pad_top + margin * (rows-1)), "white")
+    title_pad = 0
+    if title:
+        title_text_heights = [sum([line.size[1] + line_spacing for line in lines]) - line_spacing for lines in title_texts]
+        title_pad = 0 if sum(title_text_heights) == 0 else max(title_text_heights) + line_spacing * 2
+    result = Image.new("RGB", (im.width + pad_left + margin * (cols-1), im.height + pad_top + title_pad + margin * (rows-1)), "white")
     for row in range(rows):
         for col in range(cols):
             cell = im.crop((width * col, height * row, width * (col+1), height * (row+1)))
-            result.paste(cell, (pad_left + (width + margin) * col, pad_top + (height + margin) * row))
+            result.paste(cell, (pad_left + (width + margin) * col, pad_top + title_pad + (height + margin) * row))
     d = ImageDraw.Draw(result)
+    if title:
+        x = pad_left + ((width+margin)*cols) / 2
+        y = title_pad / 2 - title_text_heights[0] / 2
+        draw_texts(d, x, y, title_texts[0], fnt, fontsize)
     for col in range(cols):
         x = pad_left + (width + margin) * col + width / 2
-        y = pad_top / 2 - hor_text_heights[col] / 2
+        y = (pad_top / 2 - hor_text_heights[col] / 2) + title_pad
         draw_texts(d, x, y, hor_texts[col], fnt, fontsize)
     for row in range(rows):
         x = pad_left / 2
-        y = pad_top + (height + margin) * row + height / 2 - ver_text_heights[row] / 2
+        y = (pad_top + (height + margin) * row + height / 2 - ver_text_heights[row] / 2) + title_pad
         draw_texts(d, x, y, ver_texts[row], fnt, fontsize)
     return result
 

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -345,10 +345,10 @@ def draw_xyz_grid(p, xs, ys, zs, x_labels, y_labels, z_labels, cell, draw_legend
     for i in range(z_count):
         start_index = (i * len(xs) * len(ys)) + i
         end_index = start_index + len(xs) * len(ys)
-        if not no_grid and images.check_grid_size(processed_result.images[start_index:end_index]):
+        if (not no_grid or include_sub_grids) and images.check_grid_size(processed_result.images[start_index:end_index]):
             grid = images.image_grid(processed_result.images[start_index:end_index], rows=len(ys))
             if draw_legend:
-                grid = images.draw_grid_annotations(grid, processed_result.images[start_index].size[0], processed_result.images[start_index].size[1], hor_texts, ver_texts, margin_size)
+                grid = images.draw_grid_annotations(grid, processed_result.images[start_index].size[0], processed_result.images[start_index].size[1], hor_texts, ver_texts, margin_size, title=title_texts[i])
             processed_result.images.insert(i, grid)
         processed_result.all_prompts.insert(i, processed_result.all_prompts[start_index])
         processed_result.all_seeds.insert(i, processed_result.all_seeds[start_index])
@@ -357,7 +357,7 @@ def draw_xyz_grid(p, xs, ys, zs, x_labels, y_labels, z_labels, cell, draw_legend
     if not no_grid and images.check_grid_size(processed_result.images[:z_count]):
         z_grid = images.image_grid(processed_result.images[:z_count], rows=1)
         if draw_legend:
-            z_grid = images.draw_grid_annotations(z_grid, sub_grid_size[0], sub_grid_size[1], title_texts, [[images.GridAnnotation()]])
+            z_grid = images.draw_grid_annotations(z_grid, sub_grid_size[0], sub_grid_size[1], [[images.GridAnnotation()] for _ in z_labels], [[images.GridAnnotation()]])
         processed_result.images.insert(0, z_grid)
     #processed_result.all_prompts.insert(0, processed_result.all_prompts[0])
     #processed_result.all_seeds.insert(0, processed_result.all_seeds[0])
@@ -699,9 +699,13 @@ class Script(scripts.Script):
         z_count = len(zs)
         processed.infotexts[:1+z_count] = grid_infotext[:1+z_count] # Set the grid infotexts to the real ones with extra_generation_params (1 main grid + z_count sub-grids)
         if not include_lone_images:
-            processed.images = processed.images[:z_count+1] # Don't need sub-images anymore, drop from list:
+             # Don't need sub-images anymore, drop from list:
+            if no_grid and include_sub_grids:
+                processed.images = processed.images[:z_count] # we don't have the main grid image, and need zero additional sub-images
+            else:
+                processed.images = processed.images[:z_count+1] # we either have the main grid image, or need one sub-images
         if shared.opts.grid_save: # Auto-save main and sub-grids:
-            grid_count = z_count + 1 if z_count > 1 else 1
+            grid_count = z_count + ( 1 if not no_grid and z_count > 1 else 0 )
             for g in range(grid_count):
                 adj_g = g-1 if g > 0 else g
                 images.save_image(processed.images[g], p.outpath_grids, "xyz_grid", info=processed.infotexts[g], extension=shared.opts.grid_format, prompt=processed.all_prompts[adj_g], seed=processed.all_seeds[adj_g], grid=True, p=processed)
@@ -711,4 +715,9 @@ class Script(scripts.Script):
                 del processed.all_prompts[1]
                 del processed.all_seeds[1]
                 del processed.infotexts[1]
+        elif no_grid:
+            ##del processed.images[0]
+            #del processed.all_prompts[0]
+            #del processed.all_seeds[0]
+            del processed.infotexts[0]
         return processed


### PR DESCRIPTION
## Description

Adds the ability to just generate sub-grids, and no main grid.  Related to something I saw somewhere but can't find now.  But, I often want to create just subgrids, with such a vast number of images to fail when it comes to the main grid.  

This PR allows selecting `skip grid` (which skips the main grid), and select `include sub grids`, and just end up with subgrids, and no main grid.

Further, it adds titles to the sub grids (on their own).
