### PR TITLE
Add ENV var to dissable Gradio Frontend Check

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -266,6 +266,8 @@ def start_ui():
             favicon_path='html/logo.ico',
             allowed_paths=[os.path.dirname(__file__), cmd_opts.data_dir],
             app_kwargs=fastapi_args,
+            # Workaround for issues with Gradio Network check timeouts (edge-case, but no other workound)
+            _frontend=not os.environ.get('SD_DISABLE_GRADIO_FRONTEND_CHECK', None),
         )
     if cmd_opts.data_dir is not None:
         ui_tempdir.register_tmp_file(shared.demo, os.path.join(cmd_opts.data_dir, 'x'))


### PR DESCRIPTION
This add an ENV variable to disable the at-launch Gradio Frontend Health Check.  This check has a timeout of 3 seconds, however, with large libraries and/or network storage, this is not enough time, and can timeout, despite the app loading and launching perfectly fine.  In such cases, this ENV flag will disable the check, and allow the app to launch unencumbered. 

Does not otherwise impact loading/launch or other functionality.