### PR TITLE
HTTP API alignment with AUTOMATIC1111 (breaking change)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,6 @@
     "./repositories/stable-diffusion-stability-ai",
     "./repositories/stable-diffusion-stability-ai/ldm"
   ],
-  "python.analysis.typeCheckingMode": "off"
+  "python.analysis.typeCheckingMode": "off",
+  "editor.formatOnSave": false
 }

--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -378,6 +378,9 @@ class Api:
         if geninfo is None:
             geninfo = ""
 
+        if items and items['parameters']:
+            del items['parameters']
+
         params = generation_parameters_copypaste.parse_generation_parameters(geninfo)
         script_callbacks.infotext_pasted_callback(geninfo, params)
 
@@ -652,7 +655,7 @@ class Api:
         ext_list = []
         for ext in extensions.extensions:
             ext: extensions.Extension
-            ext.read_info_from_repo()
+            ext.read_info()
             if ext.remote is not None:
                 ext_list.append({
                     "name": ext.name,

--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -133,7 +133,7 @@ class Api:
         self.add_api_route("/sdapi/v1/embeddings", self.get_embeddings, methods=["GET"], response_model=models.EmbeddingsResponse)
         self.add_api_route("/sdapi/v1/refresh-checkpoints", self.refresh_checkpoints, methods=["POST"])
         self.add_api_route("/sdapi/v1/sd-vae", self.get_sd_vaes, methods=["GET"], response_model=List[models.SDVaeItem])
-        self.add_api_route("/sdapi/v1/refresh-vaes", self.refresh_vaes, methods=["POST"])
+        self.add_api_route("/sdapi/v1/refresh-vae", self.refresh_vaes, methods=["POST"])
         self.add_api_route("/sdapi/v1/create/embedding", self.create_embedding, methods=["POST"], response_model=models.CreateResponse)
         self.add_api_route("/sdapi/v1/create/hypernetwork", self.create_hypernetwork, methods=["POST"], response_model=models.CreateResponse)
         self.add_api_route("/sdapi/v1/preprocess", self.preprocess, methods=["POST"], response_model=models.PreprocessResponse)
@@ -464,7 +464,7 @@ class Api:
         return [{"name": upscaler.name, "model_name": upscaler.scaler.model_name, "model_path": upscaler.data_path, "model_url": None, "scale": upscaler.scale} for upscaler in shared.sd_upscalers]
 
     def get_sd_models(self):
-        return [{"title": x.title, "name": x.name, "filename": x.filename, "type": x.type, "hash": x.shorthash, "sha256": x.sha256, "config": find_checkpoint_config_near_filename(x)} for x in checkpoints_list.values()]
+        return [{"title": x.title, "model_name": x.name, "filename": x.filename, "type": x.type, "hash": x.shorthash, "sha256": x.sha256, "config": find_checkpoint_config_near_filename(x)} for x in checkpoints_list.values()]
 
     def get_hypernetworks(self):
         return [{"name": name, "path": shared.hypernetworks[name]} for name in shared.hypernetworks]

--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -245,7 +245,7 @@ class UpscalerItem(BaseModel):
 
 class SDModelItem(BaseModel):
     title: str = Field(title="Title")
-    name: str = Field(title="Model Name")
+    model_name: str = Field(title="Model Name")
     filename: str = Field(title="Filename")
     type: str = Field(title="Model type")
     sha256: Optional[str] = Field(title="SHA256 hash")

--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -170,7 +170,7 @@ class PNGInfoRequest(BaseModel):
 
 class PNGInfoResponse(BaseModel):
     info: str = Field(title="Image info", description="A string with the parameters used to generate the image")
-    items: dict = Field(title="Items", description="An object containing all the info the image had")
+    items: dict = Field(title="Items", description="A dictionary containing all the other fields the image had")
     parameters: dict = Field(title="Parameters", description="A dictionary with parsed generation info fields")
 
 class LogRequest(BaseModel):

--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -171,6 +171,7 @@ class PNGInfoRequest(BaseModel):
 class PNGInfoResponse(BaseModel):
     info: str = Field(title="Image info", description="A string with the parameters used to generate the image")
     items: dict = Field(title="Items", description="An object containing all the info the image had")
+    parameters: dict = Field(title="Parameters", description="A dictionary with parsed generation info fields")
 
 class LogRequest(BaseModel):
     lines: int = Field(default=100, title="Lines", description="How many lines to return")
@@ -209,7 +210,7 @@ for key, metadata in shared.opts.data_labels.items():
 
     if metadata is not None:
         fields.update({key: (Optional[optType], Field(
-            default=metadata.default ,description=metadata.label))})
+            default=metadata.default, description=metadata.label))})
     else:
         fields.update({key: (Optional[optType], Field())})
 
@@ -286,7 +287,6 @@ class ExtraNetworkItem(BaseModel):
     # metadata: Optional[Any] = Field(title="Metadata")
     # local: Optional[str] = Field(title="Local")
 
-
 class ArtistItem(BaseModel):
     name: str = Field(title="Name")
     score: float = Field(title="Score")
@@ -311,7 +311,6 @@ class ScriptsList(BaseModel):
     txt2img: list = Field(default=None, title="Txt2img", description="Titles of scripts (txt2img)")
     img2img: list = Field(default=None, title="Img2img", description="Titles of scripts (img2img)")
 
-
 class ScriptArg(BaseModel):
     label: str = Field(default=None, title="Label", description="Name of the argument in UI")
     value: Optional[Any] = Field(default=None, title="Value", description="Default value of the argument")
@@ -320,9 +319,17 @@ class ScriptArg(BaseModel):
     step: Optional[Any] = Field(default=None, title="Minimum", description="Step for changing value of the argumentin UI")
     choices: Optional[Any] = Field(default=None, title="Choices", description="Possible values for the argument")
 
-
 class ScriptInfo(BaseModel):
     name: str = Field(default=None, title="Name", description="Script name")
     is_alwayson: bool = Field(default=None, title="IsAlwayson", description="Flag specifying whether this script is an alwayson script")
     is_img2img: bool = Field(default=None, title="IsImg2img", description="Flag specifying whether this script is an img2img script")
     args: List[ScriptArg] = Field(title="Arguments", description="List of script's arguments")
+
+class ExtensionItem(BaseModel):
+    name: str = Field(title="Name", description="Extension name")
+    remote: str = Field(title="Remote", description="Extension Repository URL")
+    branch: str = Field(title="Branch", description="Extension Repository Branch")
+    commit_hash: str = Field(title="Commit Hash", description="Extension Repository Commit Hash")
+    version: str = Field(title="Version", description="Extension Version")
+    commit_date: str = Field(title="Commit Date", description="Extension Repository Commit Date")
+    enabled: bool = Field(title="Enabled", description="Flag specifying whether this extension is enabled")


### PR DESCRIPTION
## Main changes in this PR
* `/extensions` endpoint added
* `/refresh-vaes` aligned endpoint by moving it to `/refresh-vae` **(breaking change)**
* `/sd_models` aligned response [renamed `name` to `model_name`] **(breaking change)**
* `/png-info` aligned response [added `parameters`] and added missing script callback

## Misc changes
* Added formatOnSave: false to vscode settings.json to prevent vscode extensions from reformatting the whole file on save and causing huge irrelevant git changes. It's also obviously not used by anyone as no file seems to be formatted automatically.

## Notes
This is a breaking change for existing integrations with SD.Next's API so it should be highlighted in the changelog

Closes #2633
