### PR TITLE
fix: missing parenthesis in IPEX autocast

### DIFF
--- a/modules/intel/ipex/hijacks.py
+++ b/modules/intel/ipex/hijacks.py
@@ -28,7 +28,7 @@ def return_xpu(device):
 # Autocast
 original_autocast = torch.autocast
 def ipex_autocast(*args, **kwargs):
-    if len(args) > 0 and args[0] == "cuda" or args[0] == "xpu":
+    if len(args) > 0 and (args[0] == "cuda" or args[0] == "xpu"):
         if "dtype" in kwargs:
             return original_autocast("xpu", *args[1:], **kwargs)
         else:


### PR DESCRIPTION
## Description

The current logic is effectively `(len(args) > 0 and args[0] == "cuda") or args[0] == "xpu"` which results in indexing `args` out of bounds when `len(args) == 0`. 

## Notes

```plaintext
>>> args = []
>>> len(args) > 0 and args[0] == "a" or args[0] == "b"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
IndexError: list index out of range
>>> len(args) > 0 and (args[0] == "a" or args[0] == "b")
False
```

## Environment and Testing

Not platform specific.