### PR TITLE
Remove Thread, resolve potential race-condition

### DIFF
--- a/extensions-builtin/Lora/networks.py
+++ b/extensions-builtin/Lora/networks.py
@@ -478,5 +478,4 @@ def infotext_pasted(infotext, params): # pylint: disable=W0613
         params["Prompt"] += "\n" + "".join(added)
 
 
-thread_lora = Thread(target=list_available_networks)
-thread_lora.start()
+list_available_networks()


### PR DESCRIPTION
Simply removes the new thread in `Lora.networks`.  This thread creates a potential race-condition for other extensions, and even the Extra Networks on Large datasets.