### PR TITLE
Clean-ups within HDR features in diffuser advanced options

### DIFF
--- a/modules/processing_correction.py
+++ b/modules/processing_correction.py
@@ -63,7 +63,7 @@ def correction(p, timestep, latent):
         p.extra_generation_params["HDR center"] = f'{p.hdr_channel_shift}/{p.hdr_full_shift}'
         latent = center_tensor(latent, channel_shift=p.hdr_channel_shift, full_shift=p.hdr_full_shift)
     if timestep > 1 and timestep < 100 and p.hdr_maximize:
-        p.extra_generation_params["HDR max"] = f'{p.hdr_max_center}/p.hdr_max_boundry'
+        p.extra_generation_params["HDR max"] = f'{p.hdr_max_center}/{p.hdr_max_boundry}'
         latent = center_tensor(latent, channel_shift=p.hdr_max_center, full_shift=1.0)
         latent = maximize_tensor(latent, boundary=p.hdr_max_boundry)
     return latent

--- a/modules/ui_sections.py
+++ b/modules/ui_sections.py
@@ -130,7 +130,7 @@ def create_advanced_inputs(tab):
             with FormRow():
                 hdr_maximize = gr.Checkbox(label='HDR maximize', value=False, elem_id=f"{tab}_hdr_maximize")
                 hdr_max_center = gr.Slider(minimum=0.0, maximum=2.0, step=0.1, value=0.6,  label='Center', elem_id=f"{tab}_hdr_max_center")
-                hdr_max_boundry = gr.Slider(minimum=0.5, maximum=2.0, step=0.1, value=1.0,  label='Range', elem_id=f"{tab}_hdr_max_boundry")
+                hdr_max_boundry = gr.Slider(minimum=0.5, maximum=2.0, step=0.1, value=1.0,  label='Max Range', elem_id=f"{tab}_hdr_max_boundry")
     return cfg_scale, clip_skip, image_cfg_scale, diffusers_guidance_rescale, diffusers_sag_scale, full_quality, restore_faces, tiling, hdr_clamp, hdr_boundary, hdr_threshold, hdr_center, hdr_channel_shift, hdr_full_shift, hdr_maximize, hdr_max_center, hdr_max_boundry
 
 


### PR DESCRIPTION
## Description

While I have been trying HDR features in diffusers pipeline, I noted two tiny but obvious issues, so I want to make this fixed. There are two of them.

1. There was a not curly braced variable in f-string in extra parameter writing of HDR.
2. Two separate variables used same UI label 'Range' which caused loading from ui-config.json duplicates.

## Notes

Fixes are little and within domain of non-logical strings, hopefully not causing any break.