### PR TITLE
FaceID: Fix same images for batch

### DIFF
--- a/scripts/faceid.py
+++ b/scripts/faceid.py
@@ -102,15 +102,12 @@ def face_id(p: processing.StableDiffusionProcessing, faces, image, model, overri
 
     # main generate dict
     ip_model_dict = {
-        'prompt': p.all_prompts[0],
-        'negative_prompt': p.all_negative_prompts[0],
         'num_samples': p.batch_size,
         'width': p.width,
         'height': p.height,
         'num_inference_steps': p.steps,
         'scale': scale,
         'guidance_scale': p.cfg_scale,
-        'seed': int(p.all_seeds[0]),
         'faceid_embeds': face_embeds.shape,
     }
 
@@ -128,7 +125,15 @@ def face_id(p: processing.StableDiffusionProcessing, faces, image, model, overri
     # run generate
     images = []
     ip_model.set_scale(scale)
-    for _i in range(p.n_iter):
+    for i in range(p.n_iter):
+        # Update prompts and seed for each iteration
+        ip_model_dict.update(
+            {
+                'prompt': p.all_prompts[i],
+                'negative_prompt': p.all_negative_prompts[i],
+                'seed': int(p.all_seeds[i]),
+            }
+        )
         res = ip_model.generate(**ip_model_dict)
         if isinstance(res, list):
             images += res


### PR DESCRIPTION
## Description

Recently in https://github.com/vladmandic/automatic/commit/9ee746ef363a2db994fd9103811c54e175d6fb5b creating multiple images with the FaceID script for a batch count > 1 was implemented. This however does not account for changes in seed or prompt, meaning all N generated images will be almost identical as they use the same seed.

This PR updates the parameters, so that the seed is changed correctly.

## Notes

During testing this manually I also realized a few other things. They might be worth an issue or discussion, but I am listing them here, as I am opening this PR anyways:

* Currently images do not get saved, besides the temporary saving in Gradio - is this intended, or should they be also put in some folder?
* The factor `Strength` is currently limited between 0.0 and 1.0 - I think it would make sense to also allow a strength a bit above 1.0 (maybe 1.5), to increase likeliness, if desired. 
* The factor `Structure` does not seem to have any influence at all. (I tried the plus model which is the only one, supporting this property). I varied it from 0 to 5. Looking at the IP Adapter source code, it seems to be passed onto `image_proj_model` as `scale` parameter, but like I said, no difference on my side.

