### PR TITLE
Optionally allow RegEx to be used in the extra network search

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -648,7 +648,6 @@ options_templates.update(options_section(('extra_networks', "Extra Networks"), {
     "extra_networks_sep2": OptionInfo("<h2>Extra networks general</h2>", "", gr.HTML),
     "extra_network_skip_indexing": OptionInfo(False, "Build info on first access", gr.Checkbox),
     "extra_networks_default_multiplier": OptionInfo(1.0, "Default multiplier for extra networks", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),
-    "extra_networks_regex_search": OptionInfo(False, "Use more advanced patterns (regex) for searching (slower)", gr.Checkbox),
     "extra_networks_sep3": OptionInfo("<h2>Extra networks settings</h2>", "", gr.HTML),
     "extra_networks_styles": OptionInfo(True, "Show built-in styles"),
     "lora_preferred_name": OptionInfo("filename", "LoRA preffered name", gr.Radio, {"choices": ["filename", "alias"]}),

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -648,6 +648,7 @@ options_templates.update(options_section(('extra_networks', "Extra Networks"), {
     "extra_networks_sep2": OptionInfo("<h2>Extra networks general</h2>", "", gr.HTML),
     "extra_network_skip_indexing": OptionInfo(False, "Build info on first access", gr.Checkbox),
     "extra_networks_default_multiplier": OptionInfo(1.0, "Default multiplier for extra networks", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}),
+    "extra_networks_regex_search": OptionInfo(False, "Use more advanced patterns (regex) for searching (slower)", gr.Checkbox),
     "extra_networks_sep3": OptionInfo("<h2>Extra networks settings</h2>", "", gr.HTML),
     "extra_networks_styles": OptionInfo(True, "Show built-in styles"),
     "lora_preferred_name": OptionInfo("filename", "LoRA preffered name", gr.Radio, {"choices": ["filename", "alias"]}),


### PR DESCRIPTION
## Description

This PR adds the option to use a RegEx search for extra networks for advanced users.
This is useful to make use of a manually created folder structure among others.

For example if you have multiple folders `clothing`, but they are in a subfolder either `SD1.5` or `SDXL`, you could now search only for clothing folders in the SDXL folder.

## Notes

This adds an optional toggle to the extra network settings to enable RegEx search.
If this toggle is not set, everything behaves as before this commit. (One exception, I assume there was one mistake in https://github.com/vladmandic/automatic/blob/011bac41dffaaf4b24d3e1e760d1236ce0fa61ab/javascript/extraNetworks.js#L125-L126 as the title is used twice).

If the RegEx is toggled on, the following changes happen:

* When clicking on a menu item, the path is preprocessed before being input, so that it is valid regex which will find it
* The timeout is increased, as the RegEx search will be overall slower (depending on what queries the user writes)
* Instead of testing for the existance of the search string, the search string will be used as a regex, and applied as a test on a string in the following shape:

```JS
`filename: ${elem.dataset.filename}|name: ${elem.dataset.name}|title: ${elem.dataset.title}|tags: ${elem.dataset.tags}`
```

This specific shape allows queries to be more complex.

An example is in the demo showcase video below:


https://github.com/vladmandic/automatic/assets/18115780/422bceba-5798-429d-bf30-499386bd99ef

This video shows two examples:

Searching loras by one of either creator, and later excluding all tags which contain certain phrases.

I think it could be worth documenting this a bit on the Wiki and providing some RegEx query examples, even if this will probably only be used by a very small part of the user base.

Some examples include:

* Everything which contains SDXL and then at some point 'clothing'
```regex
SDXL.*clothing
```
* Contains either the word heel or boot
```regex
(heel|boot)
```
* Does not contain the tag `latex`
```
^(?!.*\|tags:.*latex).*$
```
* Does not contain the word `woman` or `girl` anywhere
```
^(?!.*(woman|girl)).*$
```

------------------

A majority of the usefulness of this of course depends on how well the user has sorted the models, or how well the model is tagged.