### PR TITLE
Add Auto-conversion of SD 1.5 Embeddings to SDXL

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -432,6 +432,7 @@ options_templates.update(options_section(('diffusers', "Diffusers Settings"), {
     "diffusers_force_zeros": OptionInfo(False, "Force zeros for prompts when empty", gr.Checkbox, {"visible": False}),
     "diffusers_aesthetics_score": OptionInfo(False, "Require aesthetics score"),
     "diffusers_pooled": OptionInfo("default", "Diffusers SDXL pooled embeds", gr.Radio, {"choices": ['default', 'weighted']}),
+    "diffusers_convert_embed": OptionInfo(False, "Auto-convert SD 1.5 Embeddings to SDXL ", gr.Checkbox, {"visible": True}),
     "huggingface_token": OptionInfo('', 'HuggingFace token'),
 }))
 

--- a/modules/textual_inversion/textual_inversion.py
+++ b/modules/textual_inversion/textual_inversion.py
@@ -110,9 +110,7 @@ def convert_embedding(tensor, text_encoder, text_encoder_2):
                 indices *= 0  # Use SDXL padding vector 0
             vectors.append(indices)
         vectors = torch.stack(vectors)
-        print(vectors)
         output = text_encoder_2.get_input_embeddings().weight.data[vectors]
-        print(output.shape)
     return output
 
 


### PR DESCRIPTION
Adds a naive algorithm to enable _**SOME**_  SD1.5 embeddings to produce good results on SDXL

Simply hit the checkbox  System > Diffusers Settings > Auto-convert SD 1.5 Embeddings to SDXL and load an SDXL model. 

![image](https://github.com/vladmandic/automatic/assets/54461896/175ce27c-4f90-4bc0-9d6f-5be4b06ff4f2)

[Test Embeddings](https://civitai.com/models/219575) 
