### PR TITLE
Fixed pillow font scaling in grids

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -141,7 +141,7 @@ def draw_grid_annotations(im, width, height, hor_texts, ver_texts, margin=0, tit
         for line in lines:
             font = initial_fnt
             fontsize = initial_fontsize
-            while drawing.multiline_textbbox((0,0), text=line.text, font=font)[0] > line.allowed_width and fontsize > 0:
+            while drawing.multiline_textbbox((0,0), text=line.text, font=font)[2] > line.allowed_width and fontsize > 0:
                 fontsize -= 1
                 font = get_font(fontsize)
             drawing.multiline_text((draw_x, draw_y + line.size[1] / 2), line.text, font=font, fill=shared.opts.font_color if line.is_active else color_inactive, anchor="mm", align="center")


### PR DESCRIPTION
## Description

Info texts in grids didn't scale as intended.

## Notes

Pillow's multiline_textbbox(...) returns (left, top, right, bottom). Since (0,0) is used as origin, [0] (left) will always evaluate to 0.
Fix uses [2] (right) instead.

Before:
![xyz_grid-a20240201002907 r20205064 x7 c cfg  (UniPC) (FAV__awpainting_v11) 79e2b298-a3fe-4dfa-aa03-d9bfa4ff3f4b](https://github.com/vladmandic/automatic/assets/102614013/6d09b5b9-94cd-49e2-b832-f030684ead5f)

Fixed:
![xyz_grid-a20240131224740 r20205064 x7 c cfg  (UniPC) (FAV__awpainting_v11) 7d727ec4-be14-4457-89c3-343845a83c2e](https://github.com/vladmandic/automatic/assets/102614013/5576d691-0adc-4b49-801f-8753af64dfbc)
