### PR TITLE
Hijacking Compel to enable clip skip on diffusers backend

### DIFF
--- a/modules/prompt_parser_diffusers.py
+++ b/modules/prompt_parser_diffusers.py
@@ -12,17 +12,17 @@ debug('Trace: PROMPT')
 
 def compel_hijack(self, token_ids: torch.Tensor,
                   attention_mask: typing.Optional[torch.Tensor] = None) -> torch.Tensor:
-    needs_hidden_states = self.returned_embeddings_type != 0
+    needs_hidden_states = self.returned_embeddings_type != 1
     text_encoder_output = self.text_encoder(token_ids,
                                             attention_mask,
                                             output_hidden_states=needs_hidden_states,
                                             return_dict=True)
     normalized = self.returned_embeddings_type > 0
     if normalized and needs_hidden_states:
-        clip_skip_hidden_state = text_encoder_output.hidden_states[-1 - abs(self.returned_embeddings_type)]
+        clip_skip_hidden_state = text_encoder_output.hidden_states[-abs(self.returned_embeddings_type)]
         return self.text_encoder.text_model.final_layer_norm(clip_skip_hidden_state)
     if needs_hidden_states:
-        clip_skip_hidden_state = text_encoder_output.hidden_states[-1 - abs(self.returned_embeddings_type)]
+        clip_skip_hidden_state = text_encoder_output.hidden_states[-abs(self.returned_embeddings_type)]
         return clip_skip_hidden_state
 
     return text_encoder_output.last_hidden_state


### PR DESCRIPTION
Used negative values to differentiate the need for normalized and non normalized hidden states

Testing can be done with XYZ grid.

Please test and sanity check before merging

SDXL after hijack
![image](https://github.com/vladmandic/automatic/assets/54461896/0c8ec462-390f-4935-a58c-582aeac036ce)
SDXL before hijack and Clip Skip offset
![image](https://github.com/vladmandic/automatic/assets/54461896/3ce6b598-908b-499c-b8f0-381968091a58)
