### PR TITLE
Command line support for gradio-allowed-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Below is partial list of all available parameters, run `webui --help` for the fu
       --vae VAE                        Path to VAE checkpoint to load immediately, default: None
       --data-dir DATA_DIR              Base path where all user data is stored, default:
       --models-dir MODELS_DIR          Base path where all models are stored, default: models
+      --gradio-allowed-paths OTHER_DIR Adds additional into the allowed_paths for gradio, default:
       --share                          Enable UI accessible through Gradio site, default: False
       --insecure                       Enable extensions tab regardless of other options, default: False
       --listen                         Launch web server using public IP address, default: False

--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -47,7 +47,7 @@ group.add_argument("--use-cuda", default=os.environ.get("SD_USECUDA", False), ac
 group.add_argument("--use-rocm", default=os.environ.get("SD_USEROCM", False), action='store_true', help="Force use AMD ROCm backend, default: %(default)s")
 group.add_argument('--subpath', type=str, default=os.environ.get("SD_SUBPATH", None), help='Customize the URL subpath for usage with reverse proxy')
 group.add_argument('--backend', type=str, default=os.environ.get("SD_BACKEND", None), choices=['original', 'diffusers'], required=False, help='force model pipeline type')
-
+group.add_argument("--gradio-allowed-path", action='append', required=False, help="add path to gradio's allowed_paths, make it possible to serve files from it")
 
 # removed args are added here as hidden in fixed format for compatbility reasons
 group.add_argument("-f", action='store_true', help=argparse.SUPPRESS)  # allows running as root; implemented outside of webui

--- a/webui.py
+++ b/webui.py
@@ -247,8 +247,10 @@ def start_ui():
     if cmd_opts.data_dir is not None and os.path.isdir(cmd_opts.data_dir):
         allowed_paths.append(cmd_opts.data_dir)
     # Allow the use of --gradio_allowed_path in command line
-    if cmd_opts.gradio_allowed_path is not None and os.path.isdir(cmd_opts.gradio_allowed_path[0]):
-        allowed_paths.append(cmd_opts.gradio_allowed_path[0])
+    if cmd_opts.gradio_allowed_path is not None:
+        for additional_gradio_allowed_path in cmd_opts.gradio_allowed_path:
+            if os.path.isdir(additional_gradio_allowed_path):
+                allowed_paths.append(additional_gradio_allowed_path)
     shared.log.debug(f'Root paths: {allowed_paths}')
     with contextlib.redirect_stdout(stdout):
         app, local_url, share_url = shared.demo.launch( # app is FastAPI(Starlette) instance

--- a/webui.py
+++ b/webui.py
@@ -247,8 +247,8 @@ def start_ui():
     if cmd_opts.data_dir is not None and os.path.isdir(cmd_opts.data_dir):
         allowed_paths.append(cmd_opts.data_dir)
     # Allow the use of --gradio_allowed_path in command line
-    if cmd_opts.gradio_allowed_path is not None and os.path.isdir(cmd_opts.gradio_allowed_path):
-        allowed_paths.append(cmd_opts.gradio_allowed_path)
+    if cmd_opts.gradio_allowed_path is not None and os.path.isdir(cmd_opts.gradio_allowed_path[0]):
+        allowed_paths.append(cmd_opts.gradio_allowed_path[0])
     shared.log.debug(f'Root paths: {allowed_paths}')
     with contextlib.redirect_stdout(stdout):
         app, local_url, share_url = shared.demo.launch( # app is FastAPI(Starlette) instance

--- a/webui.py
+++ b/webui.py
@@ -246,6 +246,9 @@ def start_ui():
     allowed_paths = [os.path.dirname(__file__)]
     if cmd_opts.data_dir is not None and os.path.isdir(cmd_opts.data_dir):
         allowed_paths.append(cmd_opts.data_dir)
+    # Allow the use of --gradio_allowed_path in command line
+    if cmd_opts.gradio_allowed_path is not None and os.path.isdir(cmd_opts.gradio_allowed_path):
+        allowed_paths.append(cmd_opts.gradio_allowed_path)
     shared.log.debug(f'Root paths: {allowed_paths}')
     with contextlib.redirect_stdout(stdout):
         app, local_url, share_url = shared.demo.launch( # app is FastAPI(Starlette) instance


### PR DESCRIPTION
## Description

Adds support for the command --gradio-allowed-path

This is useful if you are using symbolic links and gradio fails to serve files for previews.  Here is an example of the issue this helps resolve - https://github.com/jexom/sd-webui-depth-lib/issues/29

## Notes


## Environment and Testing

Have tested functionality on own test install.  
