### PR TITLE
Ref/files cache thumbs

### DIFF
--- a/modules/modelloader.py
+++ b/modules/modelloader.py
@@ -409,10 +409,10 @@ def load_models(model_path: str, model_url: str = None, command_path: str = None
     @param ext_filter: An optional list of filename extensions to filter by
     @return: A list of paths containing the desired model(s)
     """
-    places = list(set([model_path, command_path])) # noqa:C405
+    places = files_cache.unique_directories([model_path, command_path])
     output = []
     try:
-        output:list = [*files_cache.list_files(*places, ext_filter=ext_filter, ext_blacklist=ext_blacklist)]
+        output:list = list(files_cache.list_files(*places, ext_filter=ext_filter, ext_blacklist=ext_blacklist))
         if model_url is not None and len(output) == 0:
             if download_name is not None:
                 dl = load_file_from_url(model_url, model_dir=places[0], progress=True, file_name=download_name)
@@ -420,7 +420,7 @@ def load_models(model_path: str, model_url: str = None, command_path: str = None
             else:
                 output.append(model_url)
     except Exception as e:
-        errors.display(e,f"Error listing models: {files_cache.unique_directories(places)}")
+        errors.display(e,f"Error listing models: {places}")
     return output
 
 

--- a/modules/ui_extra_networks_textual_inversion.py
+++ b/modules/ui_extra_networks_textual_inversion.py
@@ -42,7 +42,13 @@ class ExtraNetworksPageTextualInversion(ui_extra_networks.ExtraNetworksPage):
 
     def list_items(self):
         if sd_models.model_data.sd_model is None:
-            candidates = list(files_cache.list_files(shared.opts.embeddings_dir, ext_filter=['.pt', '.safetensors'], recursive=files_cache.not_hidden))
+            '''
+            `files_cache.list_files` returns an `filter` generator, converting
+            this to a list bumps the processing time of `self.list_items` by
+            as much as 10% in certain situations.
+            I don't know why, but that's what I saw in testing.
+            '''
+            candidates = files_cache.list_files(shared.opts.embeddings_dir, ext_filter=['.pt', '.safetensors'], recursive=files_cache.not_hidden)
             self.embeddings = [
                 Embedding(vec=0, name=os.path.basename(embedding_path), filename=embedding_path)
                 for embedding_path


### PR DESCRIPTION
FilesCache Refactor/Fix:
Use thread for file system iteration, reduces networked load time by an additional 10%. This also reduced some code bloat.

FilesCache usage "Adjustments":
Reverted recent changes to Lora/Networks and the TI EN page that caused regressions in load time by as much as 10-25%.

Alternative fix for Thumbnail Resolution/Generation black-time:
Recent changes to how Thumbnails were generated aimed to reduce file-system access, and in turn created a logarithmic increase in computational load (that is to say, we both iterate and search an array of N*x items N times, where N is the number of models, and x is the average number of supplementary files per model, which in my case meant we were both iterating and searching an array of ~500k items ~50k times).  "Logarithmic" may not be the correct word, but it was profound.

This refactor moves the vast majority of Thumbnail Resolution and Generation into a single thread, as well as making it independent of the page generation.  I *will not* get a base metric to compare without, but suffice it to say I aborted the load after over 10 minutes.  IIRC, my initial loads we in excess of 20 minutes prior to working on this commit.

I have a very large collection (well in excess of 500K files when including images and info, all over a network) and startup with this commit is roughly 230 seconds.

WRT the 'fetch_file' refactor:
The added labor of resolving the thumbnail at request time (refactor of the `fetch_file` api call) does not incur a measurable impact on page load time.

This commit also includes a refactor in how the HTML for cards is generated.  This reduced page-size considerably in my testing, but may not be as profound in other cases.  This reduces page sizes by ~20mb for me. I have yet more work to do in this regard, however, as my current page size is in excess of 300mb for the HTML alone.

Final note:
My apologies for the spelling errors in the commit messages. *shrugs*