### PR TITLE
Add pytorch nightly support for ROCm 6.0 (installer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log for SD.Next
 
+## Update for 2024-02-24
+
+- **Improvements**
+  - default theme updates
+  - additional built-in theme *black-gray*
+- **Fixes**
+  - fix extra networks refresh
+  - improve ZLUDA installer when using `--use-zluda` cli param, thanks @lshqqytiger
+
 ## Update for 2024-02-22
 
 Only 3 weeks since last release, but here's another feature-packed one!

--- a/installer.py
+++ b/installer.py
@@ -923,7 +923,7 @@ def patch_zluda():
     venv_dir = os.environ.get('VENV_DIR', os.path.dirname(shutil.which('python')))
     dlls_to_patch = {
         'cublas.dll': 'cublas64_11.dll',
-        'cudnn.dll': 'cudnn64_8.dll',
+        #'cudnn.dll': 'cudnn64_8.dll',
         'cusparse.dll': 'cusparse64_11.dll',
         'nvrtc.dll': 'nvrtc64_112_0.dll',
     }

--- a/installer.py
+++ b/installer.py
@@ -488,7 +488,7 @@ def check_torch():
             log.info('Using CPU-only torch')
             torch_command = os.environ.get('TORCH_COMMAND', 'torch torchvision')
         else:
-            if rocm_ver in {"5.7"}:
+            if rocm_ver in {"5.7", "6.0"}:
                 torch_command = os.environ.get('TORCH_COMMAND', f'torch torchvision --pre --index-url https://download.pytorch.org/whl/nightly/rocm{rocm_ver}')
             elif rocm_ver in {"5.5", "5.6"}:
                 torch_command = os.environ.get('TORCH_COMMAND', f'torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm{rocm_ver}')

--- a/installer.py
+++ b/installer.py
@@ -920,7 +920,7 @@ def patch_zluda():
     if zluda_path is None:
         log.warning('Failed to automatically patch torch with ZLUDA. Could not find ZLUDA from PATH.')
         return
-    venv_path = os.path.dirname(shutil.which('python'))
+    venv_dir = os.environ.get('VENV_DIR', os.path.dirname(shutil.which('python')))
     dlls_to_patch = {
         'cublas.dll': 'cublas64_11.dll',
         'cudnn.dll': 'cudnn64_8.dll',
@@ -929,7 +929,7 @@ def patch_zluda():
     }
     try:
         for k, v in dlls_to_patch.items():
-            shutil.copyfile(os.path.join(zluda_path, k), os.path.join(venv_path, 'Lib', 'site-packages', 'torch', 'lib', v))
+            shutil.copyfile(os.path.join(zluda_path, k), os.path.join(venv_dir, 'Lib', 'site-packages', 'torch', 'lib', v))
     except Exception as e:
         log.warning(f'ZLUDA: failed to automatically patch torch: {e}')
 

--- a/javascript/black-gray.css
+++ b/javascript/black-gray.css
@@ -4,67 +4,54 @@
   --font: 'NotoSans';
   --font-mono: 'ui-monospace', 'Consolas', monospace;
   --font-size: 16px;
-  --primary-50: #7dffff;
-  --primary-100: #72e8e8;
-  --primary-200: #67d2d2;
-  --primary-300: #5dbcbc;
-  --primary-400: #52a7a7;
-  --primary-500: #489292;
-  --primary-600: #3e7d7d;
-  --primary-700: #356969;
-  --primary-800: #2b5656;
-  --primary-900: #224444;
-  --primary-950: #193232;
-  --neutral-50: #f0f0f0;
-  --neutral-100: #e0e0e0;
-  --neutral-200: #d0d0d0;
-  --neutral-300: #b0b0b0;
-  --neutral-400: #909090;
-  --neutral-500: #707070;
-  --neutral-600: #606060;
-  --neutral-700: #404040;
-  --neutral-800: #303030;
-  --neutral-900: #202020;
-  --neutral-950: #101010;
+  --primary-50: #f0f0f0;
+  --primary-100: #e0e0e0;
+  --primary-200: #d0d0d0;
+  --primary-300: #b0b0b0;
+  --primary-400: #909090;
+  --primary-500: #707070;
+  --primary-600: #606060;
+  --primary-700: #404040;
+  --primary-800: #303030;
+  --primary-900: #202020;
+  --primary-950: #101010;
   --highlight-color: var(--primary-200);
   --inactive-color: var(--primary--800);
-  --body-text-color: var(--neutral-100);
-  --body-text-color-subdued: var(--neutral-300);
-  --background-color: #050505;
-  --background-fill-primary: var(--neutral-700);
+  --body-text-color: var(--primary-100);
+  --body-text-color-subdued: var(--primary-300);
+  --background-color: var(--primary-950);
+  --background-fill-primary: var(--primary-700);
   --input-padding: 4px;
-  --input-background-fill: var(--neutral-800);
+  --input-background-fill: var(--primary-800);
   --input-shadow: none;
-  --button-secondary-text-color: var(--neutral-100);
-  --button-secondary-background-fill: linear-gradient(to bottom right, var(--neutral-400), var(--neutral-700));
-  --button-secondary-background-fill-hover: linear-gradient(to bottom right, var(--neutral-700), var(--neutral-400));
+  --button-primary-background-fill: var(--primary-600);
+  --button-primary-background-fill-hover: var(--primary-800);
+  --button-secondary-background-fill: var(--neutral-600);
+  --button-secondary-background-fill-hover: var(--neutral-800);
   --block-title-text-color: var(--neutral-300);
-  --radius-xxs: 0;
-  --radius-xs: 1;
-  --radius-sm: 2px;
-  --radius-md: 3;
-  --radius-lg: 4px;
-  --radius-xl: 5;
-  --radius-xxl: 6;
-  --line-xs: 1.0em;
-  --line-sm: 1.2em;
-  --line-md: 1.4em;
+  --radius-sm: 0;
+  --radius-lg: 0;
+  --line-xs: 0.5em;
+  --line-sm: 1.0em;
+  --line-md: 1.3em;
   --line-lg: 1.5em;
 }
 
+:root { scrollbar-color: var(--highlight-color) var(--primary-800); }
 html { font-size: var(--font-size); font-family: var(--font); }
 body, button, input, select, textarea { font-family: var(--font); }
 button { max-width: 400px; white-space: nowrap; }
 img { background-color: var(--background-color); }
-input[type=range] { height: var(--line-xs) !important; appearance: none !important; margin-top: 0 !important; min-width: max(4em, 100%) !important; background-color: var(--background-color) !important; width: 100% !important; background: transparent !important; }
-input[type=range]::-webkit-slider-runnable-track { width: 100% !important; height: 6px !important; cursor: pointer !important; background: var(--input-background-fill) !important; border-radius: var(--radius-lg) !important; border: 0px solid var(--neutral-900) !important; }
-input[type=range]::-moz-range-track              { width: 100% !important; height: 6px !important; cursor: pointer !important; background: var(--input-background-fill) !important; border-radius: var(--radius-lg) !important; border: 0px solid var(--neutral-900) !important; }
-input[type=range]::-webkit-slider-thumb { border: 0px solid #000000 !important; height: var(--line-xs) !important; width: var(--line-md) !important; border-radius: var(--radius-lg) !important; background: var(--highlight-color) !important; cursor: pointer !important; appearance: none !important; margin-top: -4px !important; }
-input[type=range]::-moz-range-thumb     { border: 0px solid #000000 !important; height: var(--line-xs) !important; width: var(--line-md) !important; border-radius: var(--radius-lg) !important; background: var(--highlight-color) !important; cursor: pointer !important; appearance: none !important; margin-top: -4px !important; }
-:root { scrollbar-color: var(--highlight-color) #303030; }
+
+input[type=range] { height: var(--line-xs) !important; appearance: none !important; margin-top: 0 !important; min-width: max(4em, 100%) !important; width: 100% !important; background: transparent !important; }
+input[type=range]::-webkit-slider-runnable-track { width: 100% !important; height: var(--line-xs) !important; cursor: pointer !important; background: var(--input-background-fill) !important; border: 0px solid var(--primary-900) !important; }
+input[type=range]::-moz-range-track              { width: 100% !important; height: var(--line-xs) !important; cursor: pointer !important; background: var(--input-background-fill) !important; border: 0px solid var(--primary-900) !important; }
+input[type=range]::-webkit-slider-thumb { border: 0px solid var(--primary-950)0 !important; height: var(--line-sm) !important; width: var(--line-sm) !important; background: var(--highlight-color) !important; cursor: pointer !important; appearance: none !important; margin-top: -4px; border-radius: 4px; }
+input[type=range]::-moz-range-thumb     { border: 0px solid var(--primary-950)0 !important; height: var(--line-sm) !important; width: var(--line-sm) !important; background: var(--highlight-color) !important; cursor: pointer !important; appearance: none !important; margin-top: -4px; border-radius: 4px; }
+
 ::-webkit-scrollbar { width: 12px; height: 12px; }
-::-webkit-scrollbar-track { background: #303030; }
-::-webkit-scrollbar-thumb { background-color: var(--highlight-color); border-radius: var(--radius-lg); border-width: 0; box-shadow: 2px 2px 3px var(--neutral-950); }
+::-webkit-scrollbar-track { background: var(--primary-800); }
+::-webkit-scrollbar-thumb { background-color: var(--highlight-color); border-width: 0; }
 div.form { border-width: 0; box-shadow: none; background: transparent; overflow: visible; }
 
 /* gradio style classes */
@@ -72,17 +59,16 @@ fieldset .gr-block.gr-box, label.block span { padding: 0; margin-top: -4px; }
 .border-2 { border-width: 0; }
 .border-b-2 { border-bottom-width: 2px; border-color: var(--highlight-color) !important; padding-bottom: 2px; margin-bottom: 8px; }
 .bg-white { color: lightyellow; background-color: var(--inactive-color); }
-.gr-box { border-radius: var(--radius-sm) !important; background-color: var(--neutral-950) !important; box-shadow: none; border-width: 0; padding: 4px; margin: 12px 0px 12px 0px }
+.gr-box { border-radius: var(--radius-sm) !important; background-color: var(--primary-950) !important; box-shadow: none; border-width: 0; padding: 4px; margin: 12px 0px 12px 0px }
 .gr-button { font-weight: normal; box-shadow: none; font-size: 0.8rem; min-width: 32px; min-height: 32px; padding: 3px; margin: 3px; }
 .gr-check-radio { background-color: var(--inactive-color); border-width: 0; border-radius: var(--radius-lg); box-shadow: none; }
 .gr-check-radio:checked { background-color: var(--highlight-color); }
 .gr-compact { background-color: var(--background-color); }
 .gr-form { border-width: 0; }
-.gr-input { background-color: #303030 !important; padding: 4px; margin: 4px; }
+.gr-input { background-color: var(--primary-300) !important; padding: 4px; margin: 4px; }
 .gr-input-label { color: lightyellow; border-width: 0; background: transparent; padding: 2px !important; }
 .gr-panel { background-color: var(--background-color); }
 .eta-bar { display: none !important }
-.gradio-slider input[type="number"] { background: var(--neutral-950); }
 svg.feather.feather-image, .feather .feather-image { display: none }
 .gap-2 { padding-top: 8px; }
 .gr-box > div > div > input.gr-text-input { right: 0; width: 4em; padding: 0; top: -12px; border: none; max-height: 20px; }
@@ -93,7 +79,7 @@ svg.feather.feather-image, .feather .feather-image { display: none }
 .px-4 { padding-lefT: 1rem; padding-right: 1rem; }
 .py-6 { padding-bottom: 0; }
 .tabs { background-color: var(--background-color); }
-.block.token-counter span { background-color: var(--input-background-fill) !important; box-shadow: 2px 2px 2px #111; border: none !important; font-size: 0.7rem; }
+.block.token-counter span { background-color: var(--input-background-fill) !important; border: none !important; font-size: 0.7rem; }
 .tab-nav { zoom: 110%; margin-top: 10px; margin-bottom: 10px; border-bottom: 2px solid var(--highlight-color) !important; padding-bottom: 2px; }
 .label-wrap { margin: 8px 0px 4px 0px; }
 .gradio-button.tool { border: none; background: none; box-shadow: none; filter: hue-rotate(340deg) saturate(0.5); }
@@ -101,10 +87,10 @@ svg.feather.feather-image, .feather .feather-image { display: none }
 #tab_extensions table tr:hover, #tab_config table tr:hover { background-color: var(--neutral-500) !important; }
 #tab_extensions table, #tab_config table { width: 96vw }
 #tab_extensions table thead, #tab_config table thead { background-color: var(--neutral-700); }
-#tab_extensions table, #tab_config table { background-color: var(--neutral-900); }
+#tab_extensions table, #tab_config table { background-color: var(--primary-900); }
 
 /* automatic style classes */
-.progressDiv { border-radius: var(--radius-sm) !important; position: fixed; top: 44px; right: 26px; max-width: 262px; height: 48px; z-index: 99; box-shadow: var(--button-shadow); }
+.progressDiv { border-radius: var(--radius-sm) !important; position: fixed; top: 44px; right: 26px; max-width: 262px; height: 48px; z-index: 99; }
 .progressDiv .progress { border-radius: var(--radius-lg) !important; background: var(--highlight-color); line-height: 3rem; height: 48px; }
 .gallery-item { box-shadow: none !important; }
 .performance { color: #888; }
@@ -122,11 +108,11 @@ svg.feather.feather-image, .feather .feather-image { display: none }
 #txt2img_prompt > label > textarea, #txt2img_neg_prompt > label > textarea, #img2img_prompt > label > textarea, #img2img_neg_prompt > label > textarea, #control_prompt > label > textarea, #control_neg_prompt > label > textarea { font-size: 1.0em; line-height: 1.4em; }
 #txt2img_styles, #img2img_styles, #control_styles { padding: 0; }
 #txt2img_styles_refresh, #img2img_styles_refresh, #control_styles_refresh { padding: 0; margin-top: 1em; }
-#img2img_settings { min-width: calc(2 * var(--left-column)); max-width: calc(2 * var(--left-column)); background-color: var(--neutral-950); padding-top: 16px; }
+#img2img_settings { min-width: calc(2 * var(--left-column)); max-width: calc(2 * var(--left-column)); background-color: var(--primary-950); padding-top: 16px; }
 #interrogate, #deepbooru { margin: 0 0px 10px 0px; max-width: 80px; max-height: 80px; font-weight: normal; font-size: 0.95em; }
 #quicksettings .gr-button-tool { font-size: 1.6rem; box-shadow: none; margin-left: -20px; margin-top: -2px; height: 2.4em; }
 #open_folder_extras, #footer, #style_pos_col, #style_neg_col, #roll_col, #extras_upscaler_2, #extras_upscaler_2_visibility, #txt2img_seed_resize_from_w, #txt2img_seed_resize_from_h { display: none; }
-#save-animation { border-radius: var(--radius-sm) !important; margin-bottom: 16px; background-color: var(--neutral-950); }
+#save-animation { border-radius: var(--radius-sm) !important; margin-bottom: 16px; background-color: var(--primary-950); }
 #script_list { padding: 4px; margin-top: 16px; margin-bottom: 8px; }
 #settings > div.flex-wrap { width: 15em; }
 #settings_search { margin-top: 1em; margin-left: 1em; }
@@ -136,7 +122,7 @@ svg.feather.feather-image, .feather .feather-image { display: none }
 textarea[rows="1"] { height: 33px !important; width: 99% !important; padding: 8px !important; }
 #extras_upscale { margin-top: 10px }
 #txt2img_progress_row > div { min-width: var(--left-column); max-width: var(--left-column); }
-#txt2img_settings { min-width: var(--left-column); max-width: var(--left-column); background-color: var(--neutral-950); padding-top: 16px; }
+#txt2img_settings { min-width: var(--left-column); max-width: var(--left-column); background-color: var(--primary-950); padding-top: 16px; }
 #pnginfo_html2_info { margin-top: -18px; background-color: var(--input-background-fill); padding: var(--input-padding) }
 #txt2img_styles_row, #img2img_styles_row, #control_styles_row { margin-top: -6px; }
 
@@ -198,23 +184,21 @@ textarea[rows="1"] { height: 33px !important; width: 99% !important; padding: 8p
   --input-shadow-focus: none;
   --loader_color: None;
   --slider_color: None;
-  --stat-background-fill: linear-gradient(to right, var(--primary-400), var(--primary-600));
+  --stat-background-fill: var(--primary-500);
   --table-border-color: var(--neutral-700);
-  --table-even-background-fill: var(--neutral-900);
+  --table-even-background-fill: var(--primary-900);
   --table-odd-background-fill: #303030;
   --table-row-focus: var(--color-accent-soft);
   --button-border-width: var(--input-border-width);
-  --button-cancel-background-fill: linear-gradient(to bottom right, #dc2626, #b91c1c);
-  --button-cancel-background-fill-hover: linear-gradient(to bottom right, #dc2626, #dc2626);
+  --button-cancel-background-fill: #b91c1c;
+  --button-cancel-background-fill-hover: #dc2626;
   --button-cancel-border-color: #dc2626;
   --button-cancel-border-color-hover: var(--button-cancel-border-color);
-  --button-cancel-text-color: var(--neutral-50);
+  --button-cancel-text-color: var(--primary-100);
   --button-cancel-text-color-hover: var(--button-cancel-text-color);
-  --button-primary-background-fill: linear-gradient(to bottom right, var(--primary-500), var(--primary-800));
-  --button-primary-background-fill-hover: linear-gradient(to bottom right, var(--primary-500), var(--primary-300));
   --button-primary-border-color: var(--primary-500);
   --button-primary-border-color-hover: var(--button-primary-border-color);
-  --button-primary-text-color: var(--neutral-50);
+  --button-primary-text-color: var(--primary-100);
   --button-primary-text-color-hover: var(--button-primary-text-color);
   --button-secondary-border-color: var(--neutral-600);
   --button-secondary-border-color-hover: var(--button-secondary-border-color);
@@ -230,12 +214,28 @@ textarea[rows="1"] { height: 33px !important; width: 99% !important; padding: 8p
   --secondary-800: #1e40af;
   --secondary-900: #1e3a8a;
   --secondary-950: #1d3660;
+  --neutral-50: #f0f0f0;
+  --neutral-100: #e0e0e0;
+  --neutral-200: #d0d0d0;
+  --neutral-300: #b0b0b0;
+  --neutral-400: #909090;
+  --neutral-500: #707070;
+  --neutral-600: #606060;
+  --neutral-700: #404040;
+  --neutral-800: #303030;
+  --neutral-900: #111827;
+  --neutral-950: #0b0f19;
+  --radius-xxs: 0;
+  --radius-xs: 0;
+  --radius-md: 0;
+  --radius-xl: 0;
+  --radius-xxl: 0;
   --body-text-size: var(--text-md);
   --body-text-weight: 400;
   --embed-radius: var(--radius-lg);
   --color-accent: var(--primary-500);
   --shadow-drop: 0;
-  --shadow-drop-lg: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  --shadow-drop-lg: 0;
   --shadow-inset: rgba(0,0,0,0.05) 0px 2px 4px 0px inset;
   --block-border-width: 1px;
   --block-info-text-size: var(--text-sm);

--- a/javascript/black-teal.css
+++ b/javascript/black-teal.css
@@ -87,7 +87,7 @@ fieldset .gr-block.gr-box, label.block span { padding: 0; margin-top: -4px; }
 .gr-input-label { color: lightyellow; border-width: 0; background: transparent; padding: 2px !important; }
 .gr-panel { background-color: var(--background-color); }
 .eta-bar { display: none !important }
-.gradio-slider input[type="number"] { background: var(--neutral-950); }
+.gradio-slider input[type="number"] { background: var(--neutral-950); margin-top: 2px; }
 svg.feather.feather-image, .feather .feather-image { display: none }
 .gap-2 { padding-top: 8px; }
 .gr-box > div > div > input.gr-text-input { right: 0; width: 4em; padding: 0; top: -12px; border: none; max-height: 20px; }
@@ -125,7 +125,7 @@ svg.feather.feather-image, .feather .feather-image { display: none }
 
 #txt2img_prompt, #txt2img_neg_prompt, #img2img_prompt, #img2img_neg_prompt, #control_prompt, #control_neg_prompt { background-color: var(--background-color); box-shadow: none !important; }
 #txt2img_prompt > label > textarea, #txt2img_neg_prompt > label > textarea, #img2img_prompt > label > textarea, #img2img_neg_prompt > label > textarea, #control_prompt > label > textarea, #control_neg_prompt > label > textarea { font-size: 1.0em; line-height: 1.4em; }
-#txt2img_styles, #img2img_styles, #control_styles { padding: 0; }
+#txt2img_styles, #img2img_styles, #control_styles { padding: 0; margin-top: 2px; }
 #txt2img_styles_refresh, #img2img_styles_refresh, #control_styles_refresh { padding: 0; margin-top: 1em; }
 #img2img_settings { min-width: calc(2 * var(--left-column)); max-width: calc(2 * var(--left-column)); background-color: var(--neutral-950); padding-top: 16px; }
 #interrogate, #deepbooru { margin: 0 0px 10px 0px; max-width: 80px; max-height: 80px; font-weight: normal; font-size: 0.95em; }

--- a/javascript/black-teal.css
+++ b/javascript/black-teal.css
@@ -4,7 +4,7 @@
   --font: 'NotoSans';
   --font-mono: 'ui-monospace', 'Consolas', monospace;
   --font-size: 16px;
-  --primary-50: #7dffff;
+  --primary-50:  #7dffff;
   --primary-100: #72e8e8;
   --primary-200: #67d2d2;
   --primary-300: #5dbcbc;
@@ -15,7 +15,7 @@
   --primary-800: #2b5656;
   --primary-900: #224444;
   --primary-950: #193232;
-  --neutral-50: #f0f0f0;
+  --neutral-50:  #f0f0f0;
   --neutral-100: #e0e0e0;
   --neutral-200: #d0d0d0;
   --neutral-300: #b0b0b0;
@@ -30,14 +30,17 @@
   --inactive-color: var(--primary--800);
   --body-text-color: var(--neutral-100);
   --body-text-color-subdued: var(--neutral-300);
-  --background-color: #050505;
+  --background-color: black;
   --background-fill-primary: var(--neutral-700);
   --input-padding: 4px;
   --input-background-fill: var(--neutral-800);
   --input-shadow: none;
+  --button-primary-text-color: var(--neutral-100);
+  --button-primary-background-fill: var(--primary-600);
+  --button-primary-background-fill-hover: var(--primary-800);
   --button-secondary-text-color: var(--neutral-100);
-  --button-secondary-background-fill: linear-gradient(to bottom right, var(--neutral-400), var(--neutral-700));
-  --button-secondary-background-fill-hover: linear-gradient(to bottom right, var(--neutral-700), var(--neutral-400));
+  --button-secondary-background-fill: var(--neutral-600);
+  --button-secondary-background-fill-hover: var(--neutral-800);
   --block-title-text-color: var(--neutral-300);
   --radius-xxs: 0;
   --radius-xs: 1;
@@ -66,6 +69,8 @@ input[type=range]::-moz-range-thumb     { border: 0px solid #000000 !important; 
 ::-webkit-scrollbar-track { background: #303030; }
 ::-webkit-scrollbar-thumb { background-color: var(--highlight-color); border-radius: var(--radius-lg); border-width: 0; box-shadow: 2px 2px 3px var(--neutral-950); }
 div.form { border-width: 0; box-shadow: none; background: transparent; overflow: visible; }
+
+.button-icon { font-size: 1.5em !important; margin: 0 !important; padding: 0 !important; height: 1.7em !important; min-height: unset !important; }
 
 /* gradio style classes */
 fieldset .gr-block.gr-box, label.block span { padding: 0; margin-top: -4px; }
@@ -210,11 +215,8 @@ textarea[rows="1"] { height: 33px !important; width: 99% !important; padding: 8p
   --button-cancel-border-color-hover: var(--button-cancel-border-color);
   --button-cancel-text-color: var(--neutral-50);
   --button-cancel-text-color-hover: var(--button-cancel-text-color);
-  --button-primary-background-fill: linear-gradient(to bottom right, var(--primary-500), var(--primary-800));
-  --button-primary-background-fill-hover: linear-gradient(to bottom right, var(--primary-500), var(--primary-300));
   --button-primary-border-color: var(--primary-500);
   --button-primary-border-color-hover: var(--button-primary-border-color);
-  --button-primary-text-color: var(--neutral-50);
   --button-primary-text-color-hover: var(--button-primary-text-color);
   --button-secondary-border-color: var(--neutral-600);
   --button-secondary-border-color-hover: var(--button-secondary-border-color);

--- a/javascript/sdnext.css
+++ b/javascript/sdnext.css
@@ -83,7 +83,7 @@ button.custom-button{ border-radius: var(--button-large-radius); padding: var(--
 #txt2img_footer, #img2img_footer, #control_footer { height: fit-content; display: none; }
 #txt2img_generate_box, #img2img_generate_box, #control_general_box { gap: 0.5em; flex-wrap: wrap-reverse; height: fit-content; }
 #txt2img_actions_column, #img2img_actions_column, #control_actions_column { gap: 0.3em; height: fit-content; }
-#txt2img_generate_box>button, #img2img_generate_box>button, #control_generate_box>button, #txt2img_enqueue, #img2img_enqueue { min-height: 44px; max-height: 44px; line-height: 1em; }
+#txt2img_generate_box>button, #img2img_generate_box>button, #control_generate_box>button, #txt2img_enqueue, #img2img_enqueue { min-height: 44px !important; max-height: 44px !important; line-height: 1em; }
 #txt2img_generate_line2, #img2img_generate_line2, #txt2img_tools, #img2img_tools, #control_generate_line2, #control_tools { display: flex; }
 #txt2img_generate_line2>button, #img2img_generate_line2>button, #extras_generate_box>button, #control_generate_line2>button, #txt2img_tools>button, #img2img_tools>button, #control_tools>button { height: 2em; line-height: 0; font-size: var(--text-md);
   min-width: unset; display: block !important; }

--- a/javascript/setHints.js
+++ b/javascript/setHints.js
@@ -41,6 +41,25 @@ async function validateHints(elements, data) {
   log('in locale but not ui:', missingUI);
 }
 
+async function replaceButtonText(el) {
+  // https://www.nerdfonts.com/cheat-sheet
+  // use unicode of icon with format nf-md-<icon>_circle
+  const textIcons = {
+    Generate: '\uf144',
+    Enqueue: '\udb81\udc17',
+    Stop: '\udb81\ude66',
+    Skip: '\udb81\ude61',
+    Pause: '\udb80\udfe5',
+    Restore: '\udb82\udd9b',
+    Clear: '\udb80\udd59',
+    Networks: '\uf261',
+  };
+  if (textIcons[el.innerText]) {
+    el.classList.add('button-icon');
+    el.innerText = textIcons[el.innerText];
+  }
+}
+
 async function setHints() {
   if (localeData.finished) return;
   if (localeData.data.length === 0) {
@@ -66,6 +85,7 @@ async function setHints() {
       localized++;
       el.textContent = found.localized;
     }
+    // replaceButtonText(el);
     if (found?.hint?.length > 0) {
       hints++;
       if (localeData.type === 1) {

--- a/modules/cmd_args.py
+++ b/modules/cmd_args.py
@@ -41,6 +41,7 @@ group.add_argument("--profile", default=os.environ.get("SD_PROFILE", False), act
 group.add_argument("--disable-queue", default=os.environ.get("SD_DISABLEQUEUE", False), action='store_true', help="Disable queues, default: %(default)s")
 group.add_argument('--debug', default=os.environ.get("SD_DEBUG", False), action='store_true', help = "Run installer with debug logging, default: %(default)s")
 group.add_argument('--use-directml', default=os.environ.get("SD_USEDIRECTML", False), action='store_true', help = "Use DirectML if no compatible GPU is detected, default: %(default)s")
+group.add_argument('--use-zluda', default=os.environ.get("SD_USEZLUDA", False), action='store_true', help = "Force use ZLUDA, AMD GPUs only, default: %(default)s")
 group.add_argument("--use-openvino", default=os.environ.get("SD_USEOPENVINO", False), action='store_true', help="Use Intel OpenVINO backend, default: %(default)s")
 group.add_argument("--use-ipex", default=os.environ.get("SD_USEIPX", False), action='store_true', help="Force use Intel OneAPI XPU backend, default: %(default)s")
 group.add_argument("--use-cuda", default=os.environ.get("SD_USECUDA", False), action='store_true', help="Force use nVidia CUDA backend, default: %(default)s")

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -407,9 +407,6 @@ options_templates.update(options_section(('cuda', "Compute Settings"), {
     "olive_vae_encoder_float32": OptionInfo(False, 'Olive force FP32 for VAE Encoder'),
     "olive_static_dims": OptionInfo(True, 'Olive use static dimensions'),
     "olive_cache_optimized": OptionInfo(True, 'Olive cache optimized models'),
-
-    "zluda_sep": OptionInfo("<h2>ZLUDA</h2>(experimental)", "", gr.HTML, {"visible": devices.backend == "cuda"}),
-    "zluda_enable_cudnn": OptionInfo(False, 'ZLUDA enable cuDNN (restart required)', gr.Checkbox, {"visible": devices.backend == "cuda"}),
 }))
 
 options_templates.update(options_section(('advanced', "Inference Settings"), {

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -251,10 +251,7 @@ class ExtraNetworksPage:
             htmls.append(self.create_html(item, tabname))
         self.html += ''.join(htmls)
         self.page_time = time.time()
-        if len(subdirs_html) > 0 or len(self.html) > 0:
-            self.html = f"<div id='{tabname}_{self_name_id}_subdirs' class='extra-network-subdirs'>{subdirs_html}</div><div id='{tabname}_{self_name_id}_cards' class='extra-network-cards'>{self.html}</div>"
-        else:
-            return ''
+        self.html = f"<div id='{tabname}_{self_name_id}_subdirs' class='extra-network-subdirs'>{subdirs_html}</div><div id='{tabname}_{self_name_id}_cards' class='extra-network-cards'>{self.html}</div>"
         shared.log.debug(f"Extra networks: page='{self.name}' items={len(self.items)} subfolders={len(subdirs)} tab={tabname} folders={self.allowed_directories_for_previews()} list={self.list_time:.2f} thumb={self.preview_time:.2f} desc={self.desc_time:.2f} info={self.info_time:.2f} workers={shared.max_workers}")
         if len(self.missing_thumbs) > 0:
             threading.Thread(target=self.create_thumb).start()
@@ -585,8 +582,6 @@ def create_ui(container, button_parent, tabname, skip_indexing = False):
                     executor.submit(page.create_items, ui.tabname)
         for page in get_pages():
             page.create_page(ui.tabname, skip_indexing)
-            if len(page.items) == 0:
-                continue
             with gr.Tab(page.title, id=page.title.lower().replace(" ", "_"), elem_classes="extra-networks-tab") as tab:
                 page_html = gr.HTML(page.html, elem_id=f'{tabname}{page.name}_extra_page', elem_classes="extra-networks-page")
                 ui.pages.append(page_html)
@@ -821,12 +816,6 @@ def create_ui(container, button_parent, tabname, skip_indexing = False):
             "prompt": prompt,
             "negative": params.get('Negative prompt', ''),
             "extra": '',
-            # "type": 'Style',
-            # "title": name,
-            # "filename": fn,
-            # "search_term": None,
-            # "preview": None,
-            # "local_preview": None,
         }
         shared.writefile(item, fn, silent=True)
         if len(prompt) > 0:

--- a/modules/zluda.py
+++ b/modules/zluda.py
@@ -3,13 +3,29 @@ import torch
 from modules import shared, devices
 
 
+def test(device: torch.device):
+    try:
+        ten1 = torch.randn((2, 4,), device=device)
+        ten2 = torch.randn((4, 8,), device=device)
+        out = torch.mm(ten1, ten2)
+        return out.sum().is_nonzero()
+    except Exception:
+        return False
+
+
 def initialize_zluda():
-    if platform.system() == "Windows" and devices.cuda_ok and torch.cuda.get_device_name(devices.get_optimal_device()).endswith("[ZLUDA]"):
-        shared.log.warning("Detected ZLUDA device. Currently, ZLUDA support is experimental and unstable.")
-        torch.backends.cudnn.enabled = shared.opts.zluda_enable_cudnn
-        if torch.backends.cudnn.enabled:
-            shared.log.warning("cuDNN with ZLUDA won't work at this moment. Please wait for future update.")
+    device = devices.get_optimal_device()
+    if platform.system() == "Windows" and devices.cuda_ok and torch.cuda.get_device_name(device).endswith("[ZLUDA]"):
+        torch.backends.cudnn.enabled = False
         torch.backends.cuda.enable_flash_sdp(False)
         torch.backends.cuda.enable_math_sdp(True)
         torch.backends.cuda.enable_mem_efficient_sdp(False)
         shared.opts.sdp_options = ['Math attention']
+        devices.device_codeformer = devices.cpu
+
+        if not test(device):
+            shared.log.error(f'ZLUDA device failed to pass basic operation test: index={device.index}, device_name={torch.cuda.get_device_name(device)}')
+            torch.cuda.is_available = lambda: False
+            devices.cuda_ok = False
+            devices.backend = 'cpu'
+            devices.device = devices.device_esrgan = devices.device_gfpgan = devices.device_interrogate = devices.cpu


### PR DESCRIPTION
## Description

Add support in the installer for downloading pytorch nightlies for ROCm 6.0. The nightlies are available now (see [#120433](https://github.com/pytorch/pytorch/issues/120433) on pytorch repo) and support in pytorch release is not expected soon.
This commit simply adds a condition to download the ROCm 6.0 package instead of falling back to ROCm 5.5.

This should address issue [#2876](https://github.com/vladmandic/automatic/issues/2876).

Successfully tested text2img on Ubuntu 22.04.03 running the latest AMD drivers (23.40.2 for Ubuntu 22.04.3 HWE with ROCm 6.0.2).

Hope this pull request is okay. Feel free to decline if not.