### PR TITLE
Add pytorch nightly support for ROCm 6.0 (installer) (dev)

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -488,7 +488,7 @@ def check_torch():
             log.info('Using CPU-only torch')
             torch_command = os.environ.get('TORCH_COMMAND', 'torch torchvision')
         else:
-            if rocm_ver in {"5.7"}:
+            if rocm_ver in {"5.7", "6.0"}:
                 torch_command = os.environ.get('TORCH_COMMAND', f'torch torchvision --pre --index-url https://download.pytorch.org/whl/nightly/rocm{rocm_ver}')
             elif rocm_ver in {"5.5", "5.6"}:
                 torch_command = os.environ.get('TORCH_COMMAND', f'torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm{rocm_ver}')


### PR DESCRIPTION
Add support in the installer for downloading pytorch nightlies for ROCm 6.0. The nightlies are available now (see https://github.com/pytorch/pytorch/issues/120433 on pytorch repo) and support in pytorch release is not expected soon.
This commit simply adds a condition to download the ROCm 6.0 package instead of falling back to ROCm 5.5.

This should address issue https://github.com/vladmandic/automatic/issues/2876.

Successfully tested text2img on Ubuntu 22.04.03 running the latest AMD drivers (23.40.2 for Ubuntu 22.04.3 HWE with ROCm 6.0.2).

This is the second pull request, this time targeting dev. Thank you for the help correctly setting this up.