### PR TITLE
Fix font fallback for amethyst-nightfall

### DIFF
--- a/javascript/amethyst-nightfall.css
+++ b/javascript/amethyst-nightfall.css
@@ -228,7 +228,7 @@ svg.feather.feather-image, .feather .feather-image { display: none }
   --radius-md: 0;
   --radius-xl: 0;
   --radius-xxl: 0;
-  --font: 'Source Sans Pro', 'ui-sans-serif', 'system-ui', sans-serif;
+  --font: 'Source Sans Pro', 'ui-sans-serif', 'system-ui', sans-serif, 'NotoSans';
   --font-mono: 'IBM Plex Mono', 'ui-monospace', 'Consolas', monospace;
   --body-text-size: var(--text-md);
   --body-text-weight: 400;


### PR DESCRIPTION
## Description

This is an additional fix to the previous PR https://github.com/vladmandic/automatic/pull/2978

In this PR I did not notice, that the `amethyst-nightfall` theme has duplicate font family definitions. 


## Notes

`:root, .light, .dark` has a higher priority as selector (and is later in the file), and thus the fallback font was not applied.

