### PR TITLE
Stable Cascade Key Matching

### DIFF
--- a/extensions-builtin/Lora/lora_convert.py
+++ b/extensions-builtin/Lora/lora_convert.py
@@ -172,6 +172,10 @@ class KeyConvert:
             if search_key.startswith(map_key):
                 key = key.replace(map_key, self.UNET_CONVERSION_MAP[map_key]).replace("oft", "lora") # pylint: disable=unsubscriptable-object
         sd_module = shared.sd_model.network_layer_mapping.get(key, None)
+        # Stable Cascade
+        if sd_module is None and "prior" in key:
+            key = key.replace("attn_", "")
+            sd_module = shared.sd_model.network_layer_mapping.get(key, None)
         # SegMoE begin
         expert_key = key + "_experts_0"
         expert_module = shared.sd_model.network_layer_mapping.get(expert_key, None)


### PR DESCRIPTION
Key Matching is complete

No Keys skipped on Stable Cascade Full

Lots of keys are skipped on Lite

tested with https://civitai.com/models/161949/piratexl?modelVersionId=398833

Errors out with `AttributeError: 'NoneType' object has no attribute 'to'` at

`/content/drive/MyDrive/vladmandic/sd/automatic/extensions-builtin/Lora/networks.py:300`