### PR TITLE
fix path handling for gallery preview

### DIFF
--- a/javascript/gallery.js
+++ b/javascript/gallery.js
@@ -110,8 +110,8 @@ async function delayFetchThumb(fn) {
 class GalleryFile extends HTMLElement {
   constructor(folder, file) {
     super();
-    this.folder = decodeURI(folder);
-    this.name = decodeURI(file);
+    this.folder = folder;
+    this.name = file;
     this.size = 0;
     this.mtime = 0;
     this.hash = undefined;
@@ -336,7 +336,7 @@ async function fetchFiles(evt) { // fetch file-by-file list over websockets
   ws.onmessage = (event) => {
     numFiles++;
     t1 = performance.now();
-    const data = event.data.split('##F##');
+    const data = decodeURI(event.data).split('##F##');
     if (data[0] === '#END#') {
       ws.close();
     } else {

--- a/modules/api/gallery.py
+++ b/modules/api/gallery.py
@@ -169,6 +169,7 @@ def register_api(app: FastAPI): # register api
                 numFiles += 1
                 file = os.path.relpath(f, folder)
                 msg = quote(folder) + '##F##' + quote(file)
+                msg = msg[:1] + ":" + msg[4:] if msg[1:4] == "%3A" else msg
                 await manager.send(ws, msg)
             await manager.send(ws, '#END#')
             t1 = time.time()


### PR DESCRIPTION
## Description
when running sd next in windows, the gallery api is not handling windows path correctly, which makes the client requesting the source img with wrong path and therefore it cant display the image after the user click the image. This pull request is to solve it

## Notes

the api `/sdapi/v1/browser/files` encode the filepath with "quote()" function, and it will encode the colon to `%3A` in the windows path, but when it sent to the client, the "decodeURI()" function wont decode the `%3A` back to colon

example:
the image path is `C:\abc\image.png`, the api will encode it to `C%3A%5Cabc%5Cimage.png`, and the client will decode it to `C%3A\abc\image.png`, and the client will request the image with `C%3A\abc\image.png`

## Environment and Testing

Windows 11 with SD Next dev branch(hash 1108c812)