### PR TITLE
Update defaults and add autodetect for VRAM optimizations

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -545,8 +545,10 @@ def check_torch():
     elif allow_ipex and (args.use_ipex or shutil.which('sycl-ls') is not None or shutil.which('sycl-ls.exe') is not None or os.environ.get('ONEAPI_ROOT') is not None or os.path.exists('/opt/intel/oneapi') or os.path.exists("C:/Program Files (x86)/Intel/oneAPI") or os.path.exists("C:/oneAPI")):
         args.use_ipex = True # pylint: disable=attribute-defined-outside-init
         log.info('Intel OneAPI Toolkit detected')
-        os.environ.setdefault('NEOReadDebugKeys', '1')
-        os.environ.setdefault('ClDeviceGlobalMemSizeAvailablePercent', '100')
+        if os.environ.get("NEOReadDebugKeys", None) is None:
+            os.environ.setdefault('NEOReadDebugKeys', '1')
+        if os.environ.get("ClDeviceGlobalMemSizeAvailablePercent", None) is None:
+            os.environ.setdefault('ClDeviceGlobalMemSizeAvailablePercent', '100')
         if "linux" in sys.platform:
             torch_command = os.environ.get('TORCH_COMMAND', 'torch==2.1.0.post0 torchvision==0.16.0.post0 intel-extension-for-pytorch==2.1.20+xpu --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/')
             os.environ.setdefault('TENSORFLOW_PACKAGE', 'tensorflow==2.15.0 intel-extension-for-tensorflow[xpu]==2.15.0.0')

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -709,13 +709,13 @@ def set_diffuser_options(sd_model, vae = None, op: str = 'model'):
             sd_model.enable_sequential_cpu_offload()
             sd_model.has_accelerate = True
     if hasattr(sd_model, "enable_vae_slicing"):
-        if shared.cmd_opts.lowvram or shared.opts.diffusers_vae_slicing:
+        if shared.opts.diffusers_vae_slicing:
             shared.log.debug(f'Setting {op}: enable VAE slicing')
             sd_model.enable_vae_slicing()
         else:
             sd_model.disable_vae_slicing()
     if hasattr(sd_model, "enable_vae_tiling"):
-        if shared.cmd_opts.lowvram or shared.opts.diffusers_vae_tiling:
+        if shared.opts.diffusers_vae_tiling:
             shared.log.debug(f'Setting {op}: enable VAE tiling')
             sd_model.enable_vae_tiling()
         else:


### PR DESCRIPTION
## Description

 - Add autodetect for VRAM optimizations.
   4 GB and below: lowvram
   8 GB and below: medvram
 - Use Dynamic Attention SDP with medvram or lowvram (except DirectML).
    This should make these GPUs able to do Hires.
 - Enable VAE Tiling for medvram and lowvram.
   This should make these GPUs able to do Hires.
 - Disable Extract EMA by default.  
   Models with EMA on CivitAI generally comes with broken EMA.  
 - Disable forced VAE Slicing for lowvram.  
   It is enabled by default anyway, user should be able to change it.
 - Make offload options reflect the CLI options in settings.  
   This will cause less confusion for users.  
 - Check `NEOReadDebugKeys` and `ClDeviceGlobalMemSizeAvailablePercent` before forcing it for IPEX.  
   Used this environment variable for changing the reported VRAM size.  


## Notes

DirectML needs testing. I am not sure if it reports the total VRAM correctly at this stage of the startup.

## Environment and Testing

Arch Linux 6.8.4 with IPEX on an ARC A770.
