### PR TITLE
update install-sf.py to handle new 1.05 stable-fast

### DIFF
--- a/cli/install-sf.py
+++ b/cli/install-sf.py
@@ -3,7 +3,7 @@ import os
 import re
 import sys
 
-torch_supported = ['211', '212','220','221']
+torch_supported = ['211', '212','220','221','222','230']
 cuda_supported = ['cu118', 'cu121']
 python_supported = ['39', '310', '311']
 repo_url = 'https://github.com/chengzeyi/stable-fast'


### PR DESCRIPTION
now supports torch 2.2.2 and 2.3.0

Seems to work with 2.3.0, didn't have any issues.