### PR TITLE
Fix Guidance (CFG & PAG) End for PAG Pipelines

### DIFF
--- a/html/locale_en.json
+++ b/html/locale_en.json
@@ -144,6 +144,7 @@
   {"id":"","label":"Batch count","localized":"","hint":"How many batches of images to create (has no impact on generation performance or VRAM usage)"},
   {"id":"","label":"Batch size","localized":"","hint":"How many image to create in a single batch (increases generation performance at cost of higher VRAM usage)"},
   {"id":"","label":"cfg scale","localized":"","hint":"Classifier Free Guidance scale: how strongly the image should conform to prompt. Lower values produce more creative results, higher values make it follow the prompt more strictly; recommended values between 5-10"},
+  {"id":"","label":"Guidance End","localized":"","hint":"Ends the effect of CFG and PAG early: A value of 1 acts as normal, 0.5 stops guidance at 50% of steps"},
   {"id":"","label":"CLIP skip","localized":"","hint":"Clip skip is a feature that allows users to control the level of specificity of the prompt, the higher the CLIP skip value, the less deep the prompt will be interpreted. CLIP Skip 1 is typical while some anime models produce better results at  CLIP skip 2"},
   {"id":"","label":"Initial seed","localized":"","hint":"A value that determines the output of random number generator - if you create an image with same parameters and seed as another image, you'll get the same result"},
   {"id":"","label":"Variation","localized":"","hint":"Second seed to be mixed with primary seed"},

--- a/modules/ui_sections.py
+++ b/modules/ui_sections.py
@@ -153,7 +153,7 @@ def create_options(tab):
 def create_cfg_inputs(tab):
     with gr.Row():
         cfg_scale = gr.Slider(minimum=0.0, maximum=30.0, step=0.1, label='CFG scale', value=6.0, elem_id=f"{tab}_cfg_scale")
-        cfg_end = gr.Slider(minimum=0.0, maximum=1.0, step=0.1, label='CFG end', value=1.0, elem_id=f"{tab}_cfg_end")
+        cfg_end = gr.Slider(minimum=0.0, maximum=1.0, step=0.1, label='Guidance end', value=1.0, elem_id=f"{tab}_cfg_end")
     return cfg_scale, cfg_end
 
 

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -234,7 +234,7 @@ axis_options = [
     AxisOption("Seed", int, apply_field("seed")),
     AxisOption("Steps", int, apply_field("steps")),
     AxisOption("CFG Scale", float, apply_field("cfg_scale")),
-    AxisOption("CFG End", float, apply_field("cfg_end")),
+    AxisOption("Guidance End", float, apply_field("cfg_end")),
     AxisOption("Variation seed", int, apply_field("subseed")),
     AxisOption("Variation strength", float, apply_field("subseed_strength")),
     AxisOption("Clip skip", float, apply_clip_skip),


### PR DESCRIPTION
Refactored CFG End to Guidance End, it now ends both CFG and PAG and added tooltip

Guidance End isn't going to give better performance on PAG pipelines. I would have to make new function to replace processors to originals, which would likely burn up any increased performance anyway, since its fairly minimal.
Fixed the callback to just set CFG to 1.001 if CFG is in use and PAG to 0.001 
Gives expected results, and fixes the current error condition.