### PR TITLE
Add four new ControlNet models for SDXL

### DIFF
--- a/modules/control/units/controlnet.py
+++ b/modules/control/units/controlnet.py
@@ -50,8 +50,8 @@ predefined_sdxl = {
     'Depth Zoe XL': 'diffusers/controlnet-zoe-depth-sdxl-1.0',
     'Depth Mid XL': 'diffusers/controlnet-depth-sdxl-1.0-mid',
     'OpenPose XL': 'thibaud/controlnet-openpose-sdxl-1.0',
-    'xinsir-controlnet-openpose-sdxl': 'xinsir/controlnet-openpose-sdxl-1.0',
-    'xinsir-controlnet-canny': 'xinsir/controlnet-canny-sdxl-1.0'
+    'Xinsir OpenPose XL': 'xinsir/controlnet-openpose-sdxl-1.0',
+    'Xinsir Canny': 'xinsir/controlnet-canny-sdxl-1.0'
     # 'StabilityAI Canny R128': 'stabilityai/control-lora/control-LoRAs-rank128/control-lora-canny-rank128.safetensors',
     # 'StabilityAI Depth R128': 'stabilityai/control-lora/control-LoRAs-rank128/control-lora-depth-rank128.safetensors',
     # 'StabilityAI Recolor R128': 'stabilityai/control-lora/control-LoRAs-rank128/control-lora-recolor-rank128.safetensors',

--- a/modules/control/units/controlnet.py
+++ b/modules/control/units/controlnet.py
@@ -50,6 +50,8 @@ predefined_sdxl = {
     'Depth Zoe XL': 'diffusers/controlnet-zoe-depth-sdxl-1.0',
     'Depth Mid XL': 'diffusers/controlnet-depth-sdxl-1.0-mid',
     'OpenPose XL': 'thibaud/controlnet-openpose-sdxl-1.0',
+    'xinsir-controlnet-openpose-sdxl': 'xinsir/controlnet-openpose-sdxl-1.0',
+    'xinsir-controlnet-canny': 'xinsir/controlnet-canny-sdxl-1.0'
     # 'StabilityAI Canny R128': 'stabilityai/control-lora/control-LoRAs-rank128/control-lora-canny-rank128.safetensors',
     # 'StabilityAI Depth R128': 'stabilityai/control-lora/control-LoRAs-rank128/control-lora-depth-rank128.safetensors',
     # 'StabilityAI Recolor R128': 'stabilityai/control-lora/control-LoRAs-rank128/control-lora-recolor-rank128.safetensors',

--- a/modules/control/units/controlnet.py
+++ b/modules/control/units/controlnet.py
@@ -51,7 +51,9 @@ predefined_sdxl = {
     'Depth Mid XL': 'diffusers/controlnet-depth-sdxl-1.0-mid',
     'OpenPose XL': 'thibaud/controlnet-openpose-sdxl-1.0',
     'Xinsir OpenPose XL': 'xinsir/controlnet-openpose-sdxl-1.0',
-    'Xinsir Canny': 'xinsir/controlnet-canny-sdxl-1.0'
+    'Xinsir Canny': 'xinsir/controlnet-canny-sdxl-1.0',
+    'Xinsir Scribble': 'xinsir/controlnet-scribble-sdxl-1.0',
+    'Xinsir Anime Painter': 'xinsir/anime-painter',
     # 'StabilityAI Canny R128': 'stabilityai/control-lora/control-LoRAs-rank128/control-lora-canny-rank128.safetensors',
     # 'StabilityAI Depth R128': 'stabilityai/control-lora/control-LoRAs-rank128/control-lora-depth-rank128.safetensors',
     # 'StabilityAI Recolor R128': 'stabilityai/control-lora/control-LoRAs-rank128/control-lora-recolor-rank128.safetensors',


### PR DESCRIPTION
## Description

This PR adds four new ControlNet models made by HF user xinsir:

- New OpenPose model (https://huggingface.co/xinsir/controlnet-openpose-sdxl-1.0)
- New Canny model (https://huggingface.co/xinsir/controlnet-canny-sdxl-1.0)
- New Scribble model (https://huggingface.co/xinsir/controlnet-scribble-sdxl-1.0)
- New "Anime Painter" model (scribble model for anime; https://huggingface.co/xinsir/anime-painter)

The OpenPose and Canny models both outperform the standard CN models and they also affect generation much less. As a plus, the OpenPose model is half the size of the one used by SD.Next.

## Notes

The models are on HF, so I just added them to the default dictionary.

## Environment and Testing

Tested with 7th Anime XL A model, a variety of poses and drawings. 
