### PR TITLE
Fix for yaml config file not being read

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ pymatting
 orjson
 invisible-watermark
 pi-heif
-diffusers==0.28.0
+diffusers==0.27.2
 safetensors==0.4.3
 tensordict==0.1.2
 peft==0.11.1


### PR DESCRIPTION
After updating diffusers to version 0.28.0, models that require yaml-config (e.g. YiffyMix v4.x) produce noise instead of a normal image. The problem is solved by changing the execution backend to original (but then all the advantages of using diffusers are lost), or by downgrading the diffusers version from 0.28.0 to 0.27.2, where this problem is not observed