### PR TITLE
Refactor diffusers embeddings load. Enable Bundled Embeddings.

### DIFF
--- a/extensions-builtin/Lora/network.py
+++ b/extensions-builtin/Lora/network.py
@@ -65,6 +65,7 @@ class Network:  # LoraModule
         self.unet_multiplier = [1.0] * 3
         self.dyn_dim = None
         self.modules = {}
+        self.bundle_embeddings = {}
         self.mtime = None
         self.mentioned_name = None
         """the text that was used to add the network to prompt - can be either name or an alias"""


### PR DESCRIPTION
Refactored Diffusers Embedding loading with future proofing in mind.

Tested on SD1.5 and SDXL Embeddings. 

As I become aware of SD3 and Pixart Sigma Embeddings in the wild, implementation should be automatic or trivial.

Added Bundled Embeddings. Trainable in OT, LoRAs can now come with embeddings inside, that are loaded at inference time. 

(Future work, show bundled embeddings inside LoRA in the EN panel)

Large dif, merge with care.
