### PR TITLE
Add uv pip as opt-in features

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -29,3 +29,7 @@ jobs:
         run: |
           export COMMANDLINE_ARGS="--debug --test"
           python launch.py
+      - name: test-startup-with-uv
+        run: |
+          export COMMANDLINE_ARGS="--debug --test --uv"
+          python launch.py

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -31,5 +31,6 @@ jobs:
           python launch.py
       - name: test-startup-with-uv
         run: |
+          rm -rf venv
           export COMMANDLINE_ARGS="--debug --test --uv"
           python launch.py

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -7,6 +7,12 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        flags:
+          - --debug --test --uv
+          - --debug --test
     steps:
       - name: checkout-code
         uses: actions/checkout@main
@@ -27,10 +33,5 @@ jobs:
           msg: apply code formatting and linting auto-fixes
       - name: test-startup
         run: |
-          export COMMANDLINE_ARGS="--debug --test"
-          python launch.py
-      - name: test-startup-with-uv
-        run: |
-          rm -rf venv
-          export COMMANDLINE_ARGS="--debug --test --uv"
+          export COMMANDLINE_ARGS="${{ matrix.flags }}"
           python launch.py

--- a/installer.py
+++ b/installer.py
@@ -242,7 +242,7 @@ def pip(arg: str, ignore: bool = False, quiet: bool = False, forcePip = False):
     uvMode = "[uv] " if uv else ""
     arg = arg.replace('>=', '==')
     if not quiet and '-r ' not in arg:
-        log.info(f'{uvMode}Install: package="{arg.replace("install", "").replace("--upgrade", "").replace("--no-deps", "").replace("--force", "").replace("  ", " ").strip()}"')
+        log.info(f'Install: package="{arg.replace("install", "").replace("--upgrade", "").replace("--no-deps", "").replace("--force", "").replace(" ", " ").strip()}" mode={"uv" if uv else "pip"}')
     env_args = os.environ.get("PIP_EXTRA_ARGS", "")
     log.debug(f'Running: {pipCmd}="{pip_log}{arg} {env_args}"')
     result = subprocess.run(f'"{sys.executable}" -m {pipCmd} {pip_log}{arg} {env_args}', shell=True, check=False, env=os.environ, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/installer.py
+++ b/installer.py
@@ -235,13 +235,14 @@ def uninstall(package, quiet = False):
 
 
 @lru_cache()
-def pip(arg: str, ignore: bool = False, quiet: bool = False):
+def pip(arg: str, ignore: bool = False, quiet: bool = False, uv=True):
     arg = arg.replace('>=', '==')
     if not quiet and '-r ' not in arg:
         log.info(f'Install: package="{arg.replace("install", "").replace("--upgrade", "").replace("--no-deps", "").replace("--force", "").replace("  ", " ").strip()}"')
     env_args = os.environ.get("PIP_EXTRA_ARGS", "")
     log.debug(f'Running: pip="{pip_log}{arg} {env_args}"')
-    result = subprocess.run(f'"{sys.executable}" -m pip {pip_log}{arg} {env_args}', shell=True, check=False, env=os.environ, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    pipCmd = "uv pip" if uv else "pip"
+    result = subprocess.run(f'"{sys.executable}" -m {pipCmd} {pip_log}{arg} {env_args}', shell=True, check=False, env=os.environ, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     txt = result.stdout.decode(encoding="utf8", errors="ignore")
     if len(result.stderr) > 0:
         txt += ('\n' if len(txt) > 0 else '') + result.stderr.decode(encoding="utf8", errors="ignore")
@@ -264,7 +265,7 @@ def install(package, friendly: str = None, ignore: bool = False, reinstall: bool
         quick_allowed = False
     if args.reinstall or reinstall or not installed(package, friendly, quiet=quiet):
         deps = '' if not no_deps else '--no-deps '
-        res = pip(f"install --upgrade {deps}{package}", ignore=ignore)
+        res = pip(f"install {deps}{package}", ignore=ignore)
         try:
             import imp # pylint: disable=deprecated-module
             imp.reload(pkg_resources)

--- a/launch.py
+++ b/launch.py
@@ -182,7 +182,6 @@ def start_server(immediate=True, server=None):
 
 def main():
     global args # pylint: disable=global-statement
-    installer.pip("install uv", uv=False)
     installer.ensure_base_requirements()
     init_args() # setup argparser and default folders
     installer.args = args
@@ -205,6 +204,9 @@ def main():
     installer.log.info(f'Platform: {installer.print_dict(installer.get_platform())}')
     if not args.skip_env:
         installer.set_environment()
+    if args.uv:
+        installer.install("uv", "uv")
+        installer.log.info('Using "uv pip" instead of "pip" for packages installation')
     installer.check_torch()
     installer.check_onnx()
     installer.check_diffusers()

--- a/launch.py
+++ b/launch.py
@@ -206,7 +206,6 @@ def main():
         installer.set_environment()
     if args.uv:
         installer.install("uv", "uv")
-        installer.log.info('Using "uv pip" instead of "pip" for packages installation')
     installer.check_torch()
     installer.check_onnx()
     installer.check_diffusers()

--- a/launch.py
+++ b/launch.py
@@ -183,6 +183,7 @@ def start_server(immediate=True, server=None):
 def main():
     global args # pylint: disable=global-statement
     installer.ensure_base_requirements()
+    installer.pip("install uv", uv=False)
     init_args() # setup argparser and default folders
     installer.args = args
     installer.setup_logging()

--- a/launch.py
+++ b/launch.py
@@ -182,8 +182,8 @@ def start_server(immediate=True, server=None):
 
 def main():
     global args # pylint: disable=global-statement
-    installer.ensure_base_requirements()
     installer.pip("install uv", uv=False)
+    installer.ensure_base_requirements()
     init_args() # setup argparser and default folders
     installer.args = args
     installer.setup_logging()


### PR DESCRIPTION
## Description

Add `--uv` flag to opt-in to replacing `pip` with `uv pip`, able to improve the speed of installing by around 30% to 50%

Ubuntu:
* With uv
![image](https://github.com/vladmandic/automatic/assets/65208589/64fda7f8-c34b-4537-ae42-3e497a1e4124)
![image](https://github.com/vladmandic/automatic/assets/65208589/9e50a2bc-1732-4c12-9af4-8f647801efd7)

* Without uv
![image](https://github.com/vladmandic/automatic/assets/65208589/7d834649-96b7-4c13-b9c9-0c699d2cfaa1)
![image](https://github.com/vladmandic/automatic/assets/65208589/a4e01a47-cc1d-456e-875a-341574e7edc6)

Windows:
* With uv
![image](https://github.com/vladmandic/automatic/assets/65208589/4805996e-878a-4b1d-80d7-4105ee6be441)
![image](https://github.com/vladmandic/automatic/assets/65208589/cf5e46e0-147a-4820-b39d-721ebf502561)


* Without uv
![image](https://github.com/vladmandic/automatic/assets/65208589/b5c39544-4578-4949-bddb-b748991479f9)
![image](https://github.com/vladmandic/automatic/assets/65208589/4b11b632-eab1-4d60-9eac-ebd65bfe68e4)


## Notes

## Environment and Testing

Ubuntu 22.04 LTS Python 3.10
Windows 11 Python 3.10
Clean Install
