### PR TITLE
Remove negative prompt embeds check for callback_on_step_end_tensor_inputs

### DIFF
--- a/modules/processing_args.py
+++ b/modules/processing_args.py
@@ -190,7 +190,7 @@ def set_pipeline_args(p, model, prompts: list, negative_prompts: list, prompts_2
     elif 'callback_on_step_end' in possible:
         args['callback_on_step_end'] = diffusers_callback
         if 'callback_on_step_end_tensor_inputs' in possible:
-            if 'prompt_embeds' in possible and 'negative_prompt_embeds' in possible and hasattr(model, '_callback_tensor_inputs'):
+            if 'prompt_embeds' in possible and hasattr(model, '_callback_tensor_inputs'):
                 args['callback_on_step_end_tensor_inputs'] = model._callback_tensor_inputs # pylint: disable=protected-access
             else:
                 args['callback_on_step_end_tensor_inputs'] = ['latents']


### PR DESCRIPTION
This PR removes the check against negative_prompt_embeds when setting callback_on_step_end_tensor_inputs.
It fixes generation with flux-dev 0.1 because flux doesn't support negative prompt embeds.

Fixes the following:
![image](https://github.com/user-attachments/assets/d7a4834f-8392-4b5c-9a9a-8a598edbc3d5)

Which results in this error:
```
18:34:52-805530 ERROR    Processing: args={'prompt': ['"hello world"'], 'guidance_scale': 3.5, 'generator':
                         [<torch._C.Generator object at 0x71c4a1500870>], 'callback_on_step_end': <function diffusers_callback
                         at 0x71c41c21fc70>, 'callback_on_step_end_tensor_inputs': ['latents'], 'num_inference_steps': 50,
                         'output_type': 'latent', 'width': 1024, 'height': 1024} not enough values to unpack (expected 2, got
                         1)
18:34:53-233480 INFO     Processed: images=0 time=1.39 its=0.00 memory={'ram': {'used': 6.92, 'total': 125.64}, 'gpu':
                         {'used': 22.85, 'total': 23.48}, 'retries': 0, 'oom': 0}
```