### PR TITLE
Update nncf to latest 2.12.0

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -575,7 +575,7 @@ def install_ipex(torch_command):
                 install(os.environ.get('MPI_PACKAGE', 'impi-devel==2021.12.0'), 'impi-devel')
         torch_command = os.environ.get('TORCH_COMMAND', f'{pytorch_pip} {torchvision_pip} {ipex_pip}')
     install(os.environ.get('OPENVINO_PACKAGE', 'openvino==2023.3.0'), 'openvino', ignore=True)
-    install('nncf==2.7.0', 'nncf', ignore=True)
+    install('nncf==2.12.0', 'nncf', ignore=True)
     install(os.environ.get('ONNXRUNTIME_PACKAGE', 'onnxruntime-openvino'), 'onnxruntime-openvino', ignore=True)
     return torch_command
 
@@ -614,7 +614,7 @@ def install_torch_addons():
     if opts.get('cuda_compile_backend', '') == 'olive-ai':
         install('olive-ai')
     if opts.get('nncf_compress_weights', False) and not args.use_openvino:
-        install('nncf==2.7.0', 'nncf')
+        install('nncf==2.12.0', 'nncf')
     if opts.get('optimum_quanto_weights', False):
         install('optimum-quanto', 'optimum-quanto')
     if triton_command is not None:

--- a/modules/control/units/controlnet.py
+++ b/modules/control/units/controlnet.py
@@ -184,7 +184,7 @@ class ControlNet():
                 try:
                     log.debug(f'Control {what} model NNCF Compress: id="{model_id}"')
                     from installer import install
-                    install('nncf==2.7.0', quiet=True)
+                    install('nncf==2.12.0', quiet=True)
                     from modules.sd_models_compile import nncf_compress_model
                     self.model = nncf_compress_model(self.model)
                 except Exception as e:

--- a/modules/model_t5.py
+++ b/modules/model_t5.py
@@ -53,7 +53,7 @@ def load_t5(t5=None, cache_dir=None):
     elif 'int8' in t5.lower():
         modelloader.hf_login()
         from installer import install
-        install('nncf==2.7.0', quiet=True)
+        install('nncf==2.12.0', quiet=True)
         from modules.sd_models_compile import nncf_compress_model
         from modules.sd_hijack import NNCF_T5DenseGatedActDense
         t5 = transformers.T5EncoderModel.from_pretrained(

--- a/modules/sd_models_compile.py
+++ b/modules/sd_models_compile.py
@@ -166,7 +166,7 @@ def nncf_compress_weights(sd_model):
         shared.log.info(f"NNCF Compress Weights: {shared.opts.nncf_compress_weights}")
         global quant_last_model_name, quant_last_model_device
         from installer import install
-        install('nncf==2.7.0', quiet=True)
+        install('nncf==2.12.0', quiet=True)
 
         sd_model = apply_compile_to_model(sd_model, nncf_compress_model, shared.opts.nncf_compress_weights, op="nncf")
         if quant_last_model_name is not None:


### PR DESCRIPTION
## Description

Update nncf to a newer version. The current version depends on a pretty old version of pyparsing and an extension I use ([sd-dynamic-prompts](https://github.com/adieyal/sd-dynamic-prompts)) requires a newer version.

## Environment and Testing

List the environment you have developed / tested this on
Tested on Windows 11 with RTX 3070 and NNCF compression enabled.