### PR TITLE
Upgrade setuptools first.

### DIFF
--- a/webui.sh
+++ b/webui.sh
@@ -81,6 +81,14 @@ else
     exit 1
 fi
 
+# Update setuptools first to make sure launch.py uses the right
+# version of it.
+setuptools=$(grep setuptools requirements.txt)
+if test ! -z "${setuptools}"; then
+    echo "Update ${setuptools} first"
+    pip install -qqq --upgrade "${setuptools}"
+fi
+
 # Add venv lib folder to PATH
 if [ -d "$(realpath "$venv_dir")/lib/" ] && [[ -z "${DISABLE_VENV_LIBS}" ]]
 then


### PR DESCRIPTION
## Description

Fix the first time crash on system with old setuptools installed.

## Notes

 It seems the python-setuptools package in debian 12 is on verison 66.1.1-1 and there is no "splat" function inside 'distutils._functools'.
While launch.py will install a new version of setuptools with version 69.5.1 (see requirements.txt) first, it seems itself will
still use the old version for the first time launch. So move the installation of setuptools to webui.sh to work around this.

## Environment and Testing

Debian 12 bookworm