### PR TITLE
fix setting t5 model

### DIFF
--- a/modules/model_te.py
+++ b/modules/model_te.py
@@ -79,7 +79,6 @@ def set_t5(pipe, module, t5=None, cache_dir=None):
         return
     if pipe is None or not hasattr(pipe, module):
         return pipe
-    t5 = None
     try:
         t5 = load_t5(t5=t5, cache_dir=cache_dir)
     except Exception as e:


### PR DESCRIPTION
This seems to be an oversight, as it leads to always setting t5 to none before trying to load t5. 