### PR TITLE
Bugfix: Unused token

### DIFF
--- a/modules/modelloader.py
+++ b/modules/modelloader.py
@@ -36,7 +36,7 @@ def hf_login(token=None):
         stdout = io.StringIO()
         with contextlib.redirect_stdout(stdout):
             hf.logout()
-            hf.login(token=shared.opts.huggingface_token, add_to_git_credential=False, write_permission=False)
+            hf.login(token=token, add_to_git_credential=False, write_permission=False)
         text = stdout.getvalue() or ''
         line = [l for l in text.split('\n') if 'Token' in l]
         shared.log.info(f'HF login: token="{hf.constants.HF_TOKEN_PATH}" {line[0] if len(line) > 0 else text}')


### PR DESCRIPTION
## Description

Download flux dev using token from the huggingface interface (even though it's not recommended, living on the edge).

## Notes
Why pass around the token at all if eventually login uses the shared value? In my (slightly outdated) version it goes `ui_models.hf_download_model -> modelloader.download_diffusers_model -> modelloader.hf_login` without having updated shared token at any point, being blank it just errs.

## Environment and Testing

