### PR TITLE
Fix UnboundLocalError on pipeline loading

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -560,10 +560,10 @@ def detect_pipeline(f: str, op: str = 'model', warning=True, quiet=False):
     guess = shared.opts.diffusers_pipeline
     warn = shared.log.warning if warning else lambda *args, **kwargs: None
     size = 0
+    pipeline = None
     if guess == 'Autodetect':
         try:
             guess = 'Stable Diffusion XL' if 'XL' in f.upper() else 'Stable Diffusion'
-            pipeline = None
             # guess by size
             if os.path.isfile(f) and f.endswith('.safetensors'):
                 size = round(os.path.getsize(f) / 1024 / 1024)


### PR DESCRIPTION
## Description

fixes regression from [db3e03c](https://github.com/vladmandic/automatic/commit/db3e03cb89cb35f06ffc64cdea36492e79fd8aa3) 

19:19:04-181546 ERROR    Load model: detect="FLUX"
                         file="models\Diffusers\models--black-forest-labs--FLUX.1-dev\snapshots\0ef5fff789c832c5c7f4e127
                         f94c8b54bbcced44" cannot access local variable 'pipeline' where it is not associated with a
                         value
19:19:04-181546 ERROR    Load model: cannot access local variable 'pipeline' where it is not associated with a value
19:19:04-183167 ERROR    Model: UnboundLocalError
╭───────────────────────────────────────── Traceback (most recent call last) ──────────────────────────────────────────╮
│ E:\stable_zluda\modules\sd_models.py:1092 in load_diffuser                                                           │
│                                                                                                                      │
│   1091 │   │   shared.log.debug(f'Load {op}: path="{checkpoint_info.path}"')                                         │
│ ❱ 1092 │   │   pipeline, model_type = detect_pipeline(checkpoint_info.path, op)                                      │
│   1093                                                                                                               │
│                                                                                                                      │
│ E:\stable_zluda\modules\sd_models.py:662 in detect_pipeline                                                          │
│                                                                                                                      │
│    661 │                                                                                                             │
│ ❱  662 │   if pipeline is None:                                                                                      │
│    663 │   │   shared.log.warning(f'Load {op}: detect="{guess}" file="{f}" size={size} not recognized')              │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
UnboundLocalError: cannot access local variable 'pipeline' where it is not associated with a value