### PR TITLE
Temporarily change the NoobAI-SDXL OpenPose repo

### DIFF
--- a/modules/control/units/controlnet.py
+++ b/modules/control/units/controlnet.py
@@ -61,7 +61,7 @@ predefined_sdxl = {
     'NoobAI Depth XL': 'Eugeoter/noob-sdxl-controlnet-depth',
     'NoobAI Normal XL': 'Eugeoter/noob-sdxl-controlnet-normal',
     'NoobAI SoftEdge XL': 'Eugeoter/noob-sdxl-controlnet-softedge_hed',
-    # 'NoobAI OpenPose XL': 'Laxhar/noob_openpose/openpose_pre.safetensors',
+    'NoobAI OpenPose XL': 'einar77/noob-openpose',
     # 'StabilityAI Canny R128': 'stabilityai/control-lora/control-LoRAs-rank128/control-lora-canny-rank128.safetensors',
     # 'StabilityAI Depth R128': 'stabilityai/control-lora/control-LoRAs-rank128/control-lora-depth-rank128.safetensors',
     # 'StabilityAI Recolor R128': 'stabilityai/control-lora/control-LoRAs-rank128/control-lora-recolor-rank128.safetensors',


### PR DESCRIPTION
## Description

The upstream repository by Laxhar Labs does not provide a `config.json`. Due to huggingface/diffusers#9976, the single-file safetensors provided can't be loaded. As such, use a mirror which provides the model in diffusers format (the model file is in that format already anyway). The 'config.json` file was copied from the other NoobAI-SDXL repositories (it's a copy paste from a SDXL repo anyway). 

Workarounds #3578 for this specific model.

## Environment and Testing

Tested with own OpenPose init image, works as intended.