### PR TITLE
Update extra_networks_lora.py

### DIFF
--- a/modules/lora/extra_networks_lora.py
+++ b/modules/lora/extra_networks_lora.py
@@ -127,7 +127,7 @@ class ExtraNetworkLora(extra_networks.ExtraNetwork):
         sd_model = getattr(shared.sd_model, "pipe", shared.sd_model)
         if not hasattr(sd_model, 'loaded_loras'):
             sd_model.loaded_loras = {}
-        key = f'{','.join(include)}:{','.join(exclude)}'
+        key = f"{','.join(include)}:{','.join(exclude)}"
         loaded = sd_model.loaded_loras.get(key, [])
         # shared.log.trace(f'Load network: type=LoRA key="{key}" requested={requested} loaded={loaded}')
         if len(requested) != len(loaded):


### PR DESCRIPTION
Latest commit causes a crash on startup with  old/fresh installs, this appears to fix it...

```
F:\automatic [master ≡]> git switch dev
branch 'dev' set up to track 'origin/dev'.
Switched to a new branch 'dev'
F:\automatic [dev ≡]> git pull
Already up to date.
F:\automatic [dev ≡]> .\webui.ps1 --listen --insecure
Using VENV: F:\automatic\venv
13:28:40-447990 INFO     Starting SD.Next
13:28:40-450492 INFO     Logger: file="F:\automatic\sdnext.log" level=INFO size=1614 mode=append
13:28:40-451496 INFO     Python: version=3.10.0 platform=Windows bin="F:\automatic\venv\Scripts\Python.exe"
                         venv="F:\automatic\venv"
13:28:40-723948 INFO     Version: app=sd.next updated=2024-12-29 hash=e010c577 branch=dev
                         url=https://github.com/vladmandic/automatic/tree/dev ui=dev
13:28:41-063144 INFO     Repository latest available 451eeab138defd158ec71a1c28cd1f3573aa1ef5 2024-12-24T13:58:24Z
13:28:41-079166 INFO     Platform: arch=AMD64 cpu=AMD64 Family 25 Model 33 Stepping 2, AuthenticAMD system=Windows
                         release=Windows-10-10.0.26100-SP0 python=3.10.0 docker=False
13:28:41-081677 INFO     Args: ['--listen', '--insecure']
13:28:41-089680 INFO     CUDA: nVidia toolkit detected
13:28:41-091185 INFO     Install: package="onnxruntime-gpu" mode=pip
13:28:54-692352 INFO     Torch: download and install in progress... cmd="torch==2.5.1+cu124 torchvision==0.20.1+cu124
                         --index-url https://download.pytorch.org/whl/cu124"
13:28:54-693355 INFO     Install: package="torch==2.5.1+cu124 torchvision==0.20.1+cu124 --index-url
                         https://download.pytorch.org/whl/cu124" mode=pip
13:30:27-784137 INFO     Install: package="onnx" mode=pip
13:30:35-811850 INFO     Install: package="onnxruntime" mode=pip
13:30:39-415671 INFO     Diffusers install: package=None current= target=6dfaec348780c6153a4cfd03a01972a291d67f82
13:31:36-095336 INFO     Install requirements: this may take a while...
13:33:51-757521 INFO     Install: verifying requirements
13:33:51-762527 INFO     Verifying packages
13:33:51-762527 INFO     Install: package="git+https://github.com/openai/CLIP.git" mode=pip
13:33:57-851614 INFO     Install: package="open-clip-torch" mode=pip
13:33:58-919134 INFO     Startup: standard
13:33:58-920133 INFO     Verifying submodules
13:34:33-777517 INFO     Extension installed packages: sd-webui-agent-scheduler ['SQLAlchemy==2.0.36',
                         'greenlet==3.1.1']
13:34:41-969425 INFO     Extension installed packages: stable-diffusion-webui-rembg ['PyMatting==1.1.13',
                         'opencv-python-headless==4.10.0.84', 'pooch==1.8.2', 'rembg==2.0.61']
13:34:41-971426 INFO     Extensions enabled: ['Lora', 'sd-extension-chainner', 'sd-extension-system-info',
                         'sd-webui-agent-scheduler', 'sdnext-modernui', 'stable-diffusion-webui-rembg']
13:34:41-972425 INFO     Install requirements: this may take a while...
13:34:41-973424 INFO     Install: verifying requirements
13:34:41-992449 INFO     Command line args: ['--listen', '--insecure'] insecure=True listen=True
13:35:02-360224 INFO     Device detect: memory=24.0 optimization=balanced
13:35:02-367731 INFO     Engine: backend=Backend.DIFFUSERS compute=cuda device=cuda attention="Scaled-Dot-Product"
                         mode=no_grad
13:35:02-896949 INFO     Available Styles: folder="models\styles" items=288 time=0.53
13:35:02-964034 INFO     Torch parameters: backend=cuda device=cuda config=Auto dtype=torch.bfloat16 vae=torch.bfloat16
                         unet=torch.bfloat16 context=no_grad nohalf=False nohalfvae=False upcast=False
                         deterministic=False test-fp16=True test-bf16=True optimization="Scaled-Dot-Product"
13:35:03-037658 INFO     Device: device=NVIDIA GeForce RTX 4090 n=1 arch=sm_90 capability=(8, 9) cuda=12.4 cudnn=90100
                         driver=566.36
13:35:03-784183 INFO     Torch: torch==2.5.1+cu124 torchvision==0.20.1+cu124
13:35:03-786692 INFO     Packages: diffusers==0.33.0.dev0 transformers==4.47.1 accelerate==1.2.1 gradio==3.43.2
13:35:05-760021 INFO     Create: folder="models\Stable-diffusion"
13:35:05-762021 INFO     Create: folder="models\Diffusers"
13:35:05-763021 INFO     Create: folder="models\VAE"
13:35:05-765021 INFO     Create: folder="models\UNET"
13:35:05-766528 INFO     Create: folder="models\Text-encoder"
13:35:05-767533 INFO     Create: folder="models\Lora"
13:35:05-768539 INFO     Create: folder="models\embeddings"
13:35:05-769540 INFO     Create: folder="models\hypernetworks"
13:35:05-771540 INFO     Create: folder="models\ONNX\temp"
13:35:05-772539 INFO     Create: folder="outputs\text"
13:35:05-774539 INFO     Create: folder="outputs\image"
13:35:05-774539 INFO     Create: folder="outputs\control"
13:35:05-777053 INFO     Create: folder="outputs\extras"
13:35:05-778059 INFO     Create: folder="outputs\init-images"
13:35:05-780059 INFO     Create: folder="outputs\grids"
13:35:05-781059 INFO     Create: folder="outputs\save"
13:35:05-782059 INFO     Create: folder="outputs\video"
13:35:05-783565 INFO     Create: folder="models\yolo"
13:35:05-784572 INFO     Create: folder="models\wildcards"
13:35:05-912773 INFO     Available VAEs: path="models\VAE" items=0
13:35:05-914773 INFO     Available UNets: path="models\UNET" items=0
13:35:05-915773 INFO     Available TEs: path="models\Text-encoder" items=0
13:35:05-918290 INFO     Available Models: items=0 safetensors="models\Stable-diffusion":0
                         diffusers="models\Diffusers":0 time=0.00
13:35:06-044977 ERROR    Uncaught exception occurred: type=<class 'SyntaxError'> value=f-string: expecting '}'
                         (extra_networks_lora.py, line 130)
13:35:06-046481 ERROR    '  File "F:\\automatic\\launch.py", line 275, in <module>\n    main()\n'
13:35:06-047485 ERROR    '  File "F:\\automatic\\launch.py", line 254, in main\n    uv, instance =
                         start_server(immediate=True, server=None)\n'
13:35:06-049489 ERROR    '  File "F:\\automatic\\launch.py", line 184, in start_server\n    uvicorn =
                         server.webui(restart=not immediate)\n'
13:35:06-050490 ERROR    '  File "F:\\automatic\\webui.py", line 336, in webui\n    start_common()\n'
13:35:06-051489 ERROR    '  File "F:\\automatic\\webui.py", line 232, in start_common\n    initialize()\n'
13:35:06-052489 ERROR    '  File "F:\\automatic\\webui.py", line 104, in initialize\n    import modules.lora.networks as
                         lora_networks\n'
13:35:06-053489 ERROR    '  File "F:\\automatic\\modules\\lora\\networks.py", line 13, in <module>\n    from
                         modules.lora.extra_networks_lora import ExtraNetworkLora\n'

```