### PR TITLE
update = to == in optimum-quanto version

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -1056,7 +1056,7 @@ def install_optional():
     install('gfpgan')
     install('clean-fid')
     install('pillow-jxl-plugin==1.3.1', ignore=True)
-    install('optimum-quanto=0.2.6', ignore=True)
+    install('optimum-quanto==0.2.6', ignore=True)
     install('bitsandbytes==0.45.0', ignore=True)
     install('pynvml', ignore=True)
     install('ultralytics==8.3.40', ignore=True)


### PR DESCRIPTION
## Description

Fix a typo in optional dependencies to skip an error during installation. Small change, annoying to see it every time I build

## Notes

Not sure there are any complications with this one

## Environment and Testing

Tested in a container build
