### PR TITLE
Added remote vae type to infotext.py and processing_info.py

### DIFF
--- a/modules/infotext.py
+++ b/modules/infotext.py
@@ -109,6 +109,8 @@ def parse(infotext):
             params[key] = False
         elif key == 'VAE' and val == 'TAESD':
             params["VAE type"] = 'Tiny'
+        elif key == 'VAE' and val == 'Remote':
+            params["VAE type"] = 'Remote'
         elif size is not None:
             params[f"{key}-1"] = int(size.group(1))
             params[f"{key}-2"] = int(size.group(2))

--- a/modules/processing_info.py
+++ b/modules/processing_info.py
@@ -74,6 +74,8 @@ def create_infotext(p: StableDiffusionProcessing, all_prompts=None, all_seeds=No
         args["VAE"] = (None if not shared.opts.add_model_name_to_info or sd_vae.loaded_vae_file is None else os.path.splitext(os.path.basename(sd_vae.loaded_vae_file))[0])
     elif p.vae_type == 'Tiny':
         args["VAE"] = 'TAESD'
+    elif p.vae_type == 'Remote':
+        args["VAE"] = 'Remote'
     if shared.opts.add_model_name_to_info and getattr(shared.sd_model, 'sd_checkpoint_info', None) is not None:
         args["Model"] = shared.sd_model.sd_checkpoint_info.model_name.replace(',', '').replace(':', '')
     if shared.opts.add_model_hash_to_info and getattr(shared.sd_model, 'sd_model_hash', None) is not None:


### PR DESCRIPTION
## Description

fixed an issue where the vae type was being ignored if it was set to remote for restoring previous generation info.

## Notes

Remote vae wasn't being stored in params.txt or image metadata, this fix allows restoring previous gen info as well as from processing tab and gallery tab and it now restores vaetype properly regardless of if its set to Full, TIny, or Remote.

## Environment and Testing

Windows 11, Android 15. Tested both modernUI and oldUI
