### PR TITLE
Fix network keywords in default UI

### DIFF
--- a/javascript/sdnext.css
+++ b/javascript/sdnext.css
@@ -1267,7 +1267,7 @@ table.settings-value-table td {
     scroll-snap-align: start;
     height: var(--card-size);
     width: var(--card-size);
-    contain: strict;
+    contain: layout style;
 }
 
 *.extra-network-cards .card-selected {


### PR DESCRIPTION
Fixes keywords not showing up in default UI on hover over card
<img width="213" height="195" alt="image" src="https://github.com/user-attachments/assets/fd597162-a064-4f19-ac5a-43c225e97343" />
