### PR TITLE
Fix default UI keyword tags

### DIFF
--- a/javascript/sdnext.css
+++ b/javascript/sdnext.css
@@ -1376,6 +1376,16 @@ table.settings-value-table td {
   display: block;
 }
 
+.extra-network-cards .card:hover {
+  z-index: 100;
+  position: relative;
+}
+
+.extra-network-cards .card:hover .tags {
+  display: block;
+  z-index: 101;  /* Optional: ensure tags are above everything */
+}
+
 .extra-network-cards .card:has(>img[src*="card-no-preview.png"])::before {
   background-color: var(--data-color);
   content: '';


### PR DESCRIPTION
Fix for model tags in default UI appearing, but being buried under card underneath it.