### PR TITLE
extraNetworks.js fix for networks menu with process caption gallery tabs

### DIFF
--- a/javascript/extraNetworks.js
+++ b/javascript/extraNetworks.js
@@ -14,8 +14,13 @@ const getENActiveTab = () => {
   else if (gradioApp().getElementById('extras_image')?.checkVisibility()) tabName = 'process';
   else if (gradioApp().getElementById('interrogate_image')?.checkVisibility()) tabName = 'caption';
   else if (gradioApp().getElementById('tab-gallery-search')?.checkVisibility()) tabName = 'gallery';
-  if (['process', 'caption', 'gallery'].includes(tabName)) tabName = lastTab;
-  else lastTab = tabName;
+
+  if (['process', 'caption', 'gallery'].includes(tabName)) {
+    tabName = lastTab;
+  } else if (tabName !== '') {
+    lastTab = tabName;
+  }
+
   if (tabName !== '') return tabName;
   // legacy method
   if (gradioApp().getElementById('tab_txt2img')?.style.display === 'block') tabName = 'txt2img';


### PR DESCRIPTION
More robust code by adding a simple check to ensure that searchTextarea is not null, added a check for debugging if it ever fails again

Fixed getENActiveTab, expression tabName in ['process', 'caption', 'gallery'] will always solve as false, making network menus inoperable when in either of these tabs.

I think it's a simple oversight as in the original UI it's not possible to open networks menu in those tabs.