### PR TITLE
Fix typo in Qwen2.5 VL 4B to 3B

### DIFF
--- a/modules/interrogate/vqa.py
+++ b/modules/interrogate/vqa.py
@@ -14,14 +14,14 @@ processor = None
 model = None
 loaded: str = None
 quant_args = None
-vlm_default = "Alibaba Qwen 2.5 VL 4B"
+vlm_default = "Alibaba Qwen 2.5 VL 3B"
 vlm_models = {
     "Google Gemma 3 4B": "google/gemma-3-4b-it",
     "Google Gemma 3n E2B": "google/gemma-3n-E2B-it", # 1.5GB
     "Google Gemma 3n E4B": "google/gemma-3n-E4B-it", # 1.5GB
     "Alibaba Qwen 2.0 VL 2B": "Qwen/Qwen2-VL-2B-Instruct",
     "Alibaba Qwen 2.5 Omni 3B": "Qwen/Qwen2.5-Omni-3B",
-    "Alibaba Qwen 2.5 VL 4B": "Qwen/Qwen2.5-VL-3B-Instruct",
+    "Alibaba Qwen 2.5 VL 3B": "Qwen/Qwen2.5-VL-3B-Instruct",
     "Huggingface Smol VL2 0.5B": "HuggingFaceTB/SmolVLM-500M-Instruct",
     "Huggingface Smol VL2 2B": "HuggingFaceTB/SmolVLM-Instruct",
     "Apple FastVLM 0.5B": "apple/FastVLM-0.5B",


### PR DESCRIPTION
https://huggingface.co/Qwen/Qwen2.5-VL-3B-Instruct has been wrongly named 4B in Captioning menu.