### PR TITLE
Add VAE scale override for ChronoEditPipeline

### DIFF
--- a/modules/sd_vae.py
+++ b/modules/sd_vae.py
@@ -14,6 +14,7 @@ debug = os.environ.get('SD_LOAD_DEBUG', None) is not None
 unspecified = object()
 vae_scale_override = {
     'WanPipeline': 16,
+    'ChronoEditPipeline': 16,
 }
 
 


### PR DESCRIPTION
Fixes automatic rescale of input images for ChronoEdit