### PR TITLE
Fix/Improve Extra Networks init

### DIFF
--- a/javascript/extraNetworks.js
+++ b/javascript/extraNetworks.js
@@ -465,23 +465,24 @@ function setupExtraNetworksForTab(tabName) {
   // card hover
   let hoverTimer = null;
   let previousCard = null;
-  if (window.opts.extra_networks_fetch) {
-    gradioApp().getElementById(`${tabName}_extra_tabs`).onmouseover = async (e) => {
-      const el = e.target.closest('.card'); // bubble-up to card
-      if (!el || (el.title === previousCard)) return;
-      if (!hoverTimer) {
-        hoverTimer = setTimeout(() => {
-          readCardDescription(el.dataset.page, el.dataset.name);
-          readCardTags(el, el.dataset.tags);
-          previousCard = el.title;
-        }, 300);
-      }
-      el.onmouseout = () => {
-        clearTimeout(hoverTimer);
-        hoverTimer = null;
-      };
+  gradioApp().getElementById(`${tabName}_extra_tabs`).onmouseover = async (e) => {
+    if (!window.opts.extra_networks_fetch) {
+      return;
+    }
+    const el = e.target.closest('.card'); // bubble-up to card
+    if (!el || (el.title === previousCard)) return;
+    if (!hoverTimer) {
+      hoverTimer = setTimeout(() => {
+        readCardDescription(el.dataset.page, el.dataset.name);
+        readCardTags(el, el.dataset.tags);
+        previousCard = el.title;
+      }, 300);
+    }
+    el.onmouseout = () => {
+      clearTimeout(hoverTimer);
+      hoverTimer = null;
     };
-  }
+  };
 
   // auto-resize networks sidebar
   const resizeObserver = new ResizeObserver((entries) => {


### PR DESCRIPTION
## Description

- Fixes the rare occurrence where the cards in Extra Networks would be configured before `window.opts` was fully populated, resulting in the CSS variable `--card-size` being set to "undefinedpx".
- Fixes the "UI fetch network info on mouse-over" (`extra_networks_fetch`) setting requiring a ~restart~ page refresh to take effect.

## Notes

In theory the card size issue could also be resolved as follows, but it could result in `setupExtraNetworks` resolving before everything was actually complete.
```javascript
  async function waitForCardSize() {
    while (window.opts.extra_networks_card_size === undefined) {
      await sleep(50)
    }
  }

  waitForCardSize()
    .then(() => {
      log('initNetworks', window.opts.extra_networks_card_size);
      document.documentElement.style.setProperty('--card-size', `${window.opts.extra_networks_card_size}px`);
    });
```
I chose to go with the `await` method so that if there's ever anything that has to rely on Extra Networks being fully setup, it can be `.then()`'ed onto the `setupExtraNetworks()` call in `startup.js`.