### PR TITLE
Log fix

### DIFF
--- a/javascript/logMonitor.js
+++ b/javascript/logMonitor.js
@@ -24,7 +24,7 @@ function htmlEscape(text) {
 async function logMonitor() {
   const addLogLine = (line) => {
     try {
-      const l = JSON.parse(line.replaceAll('\n', ' '));
+      const l = JSON.parse(line.replaceAll('\n', ' ').replaceAll('\\', '\\\\'));
       const row = document.createElement('tr');
       // row.style = 'padding: 10px; margin: 0;';
       const level = `<td style="color: var(--color-${l.level.toLowerCase()})">${l.level}</td>`;


### PR DESCRIPTION
Just a couple of small fixes for `logMonitor.js`:
- More useful info when encountering an error.
- Fix lora tags being interpreted as HTML tags.
- Fix backslashes because the message contents are going through `JSON.parse()` a second time.
_Blah blah probably something to do with logger records being str representations of dict objects._