### PR TITLE
Remove conditional Hires sampler omission

### DIFF
--- a/modules/processing_info.py
+++ b/modules/processing_info.py
@@ -106,7 +106,7 @@ def create_infotext(p: StableDiffusionProcessing, all_prompts=None, all_seeds=No
             args["Hires force"] = p.hr_force
             args["Hires steps"] = p.hr_second_pass_steps
             args["Hires strength"] = p.hr_denoising_strength
-            args["Hires sampler"] = p.hr_sampler_name if p.hr_sampler_name != p.sampler_name else None
+            args["Hires sampler"] = p.hr_sampler_name
             args["Hires CFG scale"] = p.image_cfg_scale
     if 'refine' in p.ops:
         args["Refine"] = p.enable_hr


### PR DESCRIPTION
Fixes restoring parameters when your default hires sampler isn't "Same as primary". In those cases, only the main sampler would be updated because there's no value stored for the hires sampler.

While technically you *could* assume that "Same as primary" is meant when other hires settings are loaded without a value for the sampler, it would be a lot more complicated to actually implement. Honestly, it's just better and probably more "expected behavior" to always include the information when using Hires.