### PR TITLE
[hotfix] Fix cache clearing when switching folders

### DIFF
--- a/javascript/gallery.js
+++ b/javascript/gallery.js
@@ -7,6 +7,7 @@ let outstanding = 0;
 let lastSort = 0;
 let lastSortName = 'None';
 let idbIsCleaning = false;
+let activeGalleryFolder = '';
 const galleryHashes = new Set();
 // Store separator states for the session
 const separatorStates = new Map();
@@ -592,10 +593,10 @@ async function thumbCacheCleanup() {
   }
 
   const removeOverlayFunc = showCleaningMsg();
-  idbClean(galleryHashes)
-    .then((delcount) => {
+  idbClean(galleryHashes, activeGalleryFolder)
+    .then((delcount, folder) => {
       const t1 = performance.now();
-      log(`Thumbnail DB cleanup: kept=${galleryHashes.size} deleted=${delcount} time=${Math.floor(t1 - t0)}ms`);
+      log(`Thumbnail DB cleanup: folder=${folder} kept=${galleryHashes.size} deleted=${delcount} time=${Math.floor(t1 - t0)}ms`);
     })
     .catch((err) => {
       error('Thumbnail DB cleanup: Cleanup failed.', err.message);
@@ -632,6 +633,7 @@ async function fetchFilesHT(evt) {
   el.files.appendChild(fragment);
 
   const t1 = performance.now();
+  activeGalleryFolder = evt.target.name;
   log(`gallery: folder=${evt.target.name} num=${numFiles} time=${Math.floor(t1 - t0)}ms`);
   updateStatusWithSort(`Folder: ${evt.target.name} | ${numFiles.toLocaleString()} images | ${Math.floor(t1 - t0).toLocaleString()}ms`);
   addSeparators();
@@ -686,6 +688,7 @@ async function fetchFilesWS(evt) { // fetch file-by-file list over websockets
   ws.onclose = (event) => {
     el.files.appendChild(fragment);
     // gallerySort();
+    activeGalleryFolder = evt.target.name;
     log(`gallery: folder=${evt.target.name} num=${numFiles} time=${Math.floor(t1 - t0)}ms`);
     updateStatusWithSort(`Folder: ${evt.target.name} | ${numFiles.toLocaleString()} images | ${Math.floor(t1 - t0).toLocaleString()}ms`);
     addSeparators();

--- a/javascript/indexdb.js
+++ b/javascript/indexdb.js
@@ -99,10 +99,13 @@ async function idbCount() {
   });
 }
 
-async function idbClean(keepSet) {
+async function idbClean(keepSet, folder = null) {
   if (!db) return null;
   if (!(keepSet instanceof Set)) {
     throw new TypeError('IndexedDB cleaning function must be given a Set() of hashes to keep');
+  }
+  if (folder === null) {
+    throw new Error('IndexedDB cleaning function must be told the current active folder');
   }
   return new Promise((resolve, reject) => {
     let counter = 0;
@@ -113,13 +116,13 @@ async function idbClean(keepSet) {
     request.onsuccess = (evt) => {
       const cursor = evt.target.result;
       if (cursor) {
-        if (!keepSet.has(cursor.key)) {
+        if (folder === cursor.value.folder && !keepSet.has(cursor.key)) {
           cursor.delete();
           counter++;
         }
         cursor.continue();
       } else {
-        resolve(counter);
+        resolve(counter, folder);
       }
     };
     request.onerror = (evt) => reject(evt);


### PR DESCRIPTION
This is more of a temporary hotfix since trying to change folders won't work while it's counting and the message will always kick off when viewing small folders.

Looking into a better solution, but if I can't figure out something that works without getting in the way then I'll probably just change it to a manually-run process.

Also, made a little mistake during the rebase process, so this one should be a **squash commit** to hide the first two unrelated commits that cancel each other out.