### PR TITLE
Fix import for SDNQ options and Qwen models in load_sdnq

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -168,7 +168,7 @@ def set_diffuser_options(sd_model, vae=None, op:str='model', offload:bool=True, 
         module = getattr(sd_model, module_name, None)
         if hasattr(module, "quantization_config") and getattr(module.quantization_config, "quant_method", None) == "sdnq":
             if module.quantization_config.use_quantized_matmul != shared.opts.sdnq_use_quantized_matmul:
-                from sdnq.loader import apply_sdnq_options_to_model
+                from modules.sdnq.loader import apply_sdnq_options_to_model
                 shared.log.debug(f'Setting {op} {module_name}: sdnq_use_quantized_matmul={shared.opts.sdnq_use_quantized_matmul}')
                 module = apply_sdnq_options_to_model(module, use_quantized_matmul=shared.opts.sdnq_use_quantized_matmul)
                 setattr(sd_model, module_name, module)

--- a/modules/sdnq/loader.py
+++ b/modules/sdnq/loader.py
@@ -133,6 +133,11 @@ def load_sdnq_model(model_path: str, model_cls: ModelMixin = None, file_name: st
     if model.__class__.__name__ in {"T5EncoderModel", "UMT5EncoderModel"} and "encoder.embed_tokens.weight" not in state_dict.keys():
         state_dict["encoder.embed_tokens.weight"] = state_dict["shared.weight"]
 
+    # Handle Qwen models with tied lm_head weights
+    if model.__class__.__name__ in {"Qwen3ForCausalLM"} and "lm_head.weight" not in state_dict.keys():
+        if "model.embed_tokens.weight" in state_dict.keys():
+            state_dict["lm_head.weight"] = state_dict["model.embed_tokens.weight"]
+
     model.load_state_dict(state_dict, assign=True)
     del state_dict
 


### PR DESCRIPTION
## Description

Fixes two errors, import not found for SDNQ during loading, and handling of Qwen3 models in the loader.