### PR TITLE
Fix importlib usage

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -10,7 +10,8 @@ import logging
 import platform
 import subprocess
 import cProfile
-import importlib # pylint: disable=deprecated-module
+import importlib
+import importlib.util
 
 
 class Dot(dict): # dot notation access to dictionary attributes

--- a/modules/ggml/__init__.py
+++ b/modules/ggml/__init__.py
@@ -10,7 +10,7 @@ def install_gguf():
     # https://github.com/ggerganov/llama.cpp/issues/9566
     from installer import install
     install('gguf', quiet=True)
-    import importlib
+    import importlib.metadata
     import gguf
     from modules import shared
     scripts_dir = os.path.join(os.path.dirname(gguf.__file__), '..', 'scripts')


### PR DESCRIPTION
`importlib.util` has required being explicitly imported for quite some time. The fact that this code worked at all is only because `launch.py` was called before `installer.py`.

Same goes for `importlib.metadata`, although I'm not sure how (or if) that code was still working.