### PR TITLE
show_progress requires "full", "minimal", or "hidden"

### DIFF
--- a/modules/control/unit.py
+++ b/modules/control/unit.py
@@ -180,7 +180,7 @@ class Unit(): # mashup of gradio controls and mapping to actual implementation c
                     self.adapter.load(model_id)
                 else:
                     self.controls.append(model_id)
-                    model_id.change(fn=self.adapter.load, inputs=[model_id], outputs=[result_txt], show_progress=True)
+                    model_id.change(fn=self.adapter.load, inputs=[model_id], outputs=[result_txt], show_progress='full')
             if extra_controls is not None and len(extra_controls) > 0:
                 extra_controls[0].change(fn=adapter_extra, inputs=extra_controls)
         elif self.type == 'controlnet':
@@ -189,8 +189,8 @@ class Unit(): # mashup of gradio controls and mapping to actual implementation c
                     self.controlnet.load(model_id)
                 else:
                     self.controls.append(model_id)
-                    model_id.change(fn=self.controlnet.load, inputs=[model_id], outputs=[result_txt], show_progress=True)
-                    model_id.change(fn=control_choices, inputs=[model_id], outputs=[control_mode, control_tile], show_progress=False)
+                    model_id.change(fn=self.controlnet.load, inputs=[model_id], outputs=[result_txt], show_progress='full')
+                    model_id.change(fn=control_choices, inputs=[model_id], outputs=[control_mode, control_tile], show_progress='hidden')
             if extra_controls is not None and len(extra_controls) > 0:
                 extra_controls[0].change(fn=controlnet_extra, inputs=extra_controls)
         elif self.type == 'xs':
@@ -199,7 +199,7 @@ class Unit(): # mashup of gradio controls and mapping to actual implementation c
                     self.controlnet.load(model_id)
                 else:
                     self.controls.append(model_id)
-                    model_id.change(fn=self.controlnet.load, inputs=[model_id, extra_controls[0]], outputs=[result_txt], show_progress=True)
+                    model_id.change(fn=self.controlnet.load, inputs=[model_id, extra_controls[0]], outputs=[result_txt], show_progress='full')
             if extra_controls is not None and len(extra_controls) > 0:
                 extra_controls[0].change(fn=controlnetxs_extra, inputs=extra_controls)
         elif self.type == 'lite':
@@ -208,7 +208,7 @@ class Unit(): # mashup of gradio controls and mapping to actual implementation c
                     self.controlnet.load(model_id)
                 else:
                     self.controls.append(model_id)
-                    model_id.change(fn=self.controlnet.load, inputs=[model_id], outputs=[result_txt], show_progress=True)
+                    model_id.change(fn=self.controlnet.load, inputs=[model_id], outputs=[result_txt], show_progress='full')
             if extra_controls is not None and len(extra_controls) > 0:
                 extra_controls[0].change(fn=controlnetxs_extra, inputs=extra_controls)
         elif self.type == 'reference':
@@ -229,7 +229,7 @@ class Unit(): # mashup of gradio controls and mapping to actual implementation c
                 self.process.load(process_id)
             else:
                 self.controls.append(process_id)
-                process_id.change(fn=self.process.load, inputs=[process_id], outputs=[result_txt], show_progress=True)
+                process_id.change(fn=self.process.load, inputs=[process_id], outputs=[result_txt], show_progress='full')
         if reset_btn is not None:
             reset_btn.click(fn=self.reset, inputs=[], outputs=[enabled_cb, model_id, process_id, model_strength])
         if preview_btn is not None:

--- a/modules/framepack/framepack_ui.py
+++ b/modules/framepack/framepack_ui.py
@@ -115,6 +115,6 @@ def create_ui(prompt, negative, styles, _overrides, init_image, last_image, mp4_
         _js="submit_framepack",
         inputs=state_inputs + framepack_inputs,
         outputs=framepack_outputs,
-        show_progress=False,
+        show_progress='hidden',
     )
     generate.click(**framepack_dict)

--- a/modules/generation_parameters_copypaste.py
+++ b/modules/generation_parameters_copypaste.py
@@ -158,7 +158,7 @@ def connect_paste_params_buttons():
                 fn=send_image,
                 inputs=[binding.source_image_component],
                 outputs=[destination_image_component],
-                show_progress=False,
+                show_progress='hidden',
             )
 
         override_settings_component = binding.override_settings_component or paste_fields[binding.tabname]["override_settings_component"]
@@ -177,7 +177,7 @@ def connect_paste_params_buttons():
             _js=f"switch_to_{binding.tabname}",
             inputs=[],
             outputs=[],
-            show_progress=False,
+            show_progress='hidden',
         )
 
 
@@ -294,12 +294,12 @@ def connect_paste(button, local_paste_fields, input_comp, override_settings_comp
         fn=paste_func,
         inputs=[input_comp],
         outputs=[x[0] for x in local_paste_fields],
-        show_progress=False,
+        show_progress='hidden',
     )
     button.click(
         fn=None,
         _js=f"recalculate_prompts_{tabname}",
         inputs=[],
         outputs=[],
-        show_progress=False,
+        show_progress='hidden',
     )

--- a/modules/ltx/ltx_ui.py
+++ b/modules/ltx/ltx_ui.py
@@ -72,6 +72,6 @@ def create_ui(prompt, negative, styles, overrides, init_image, init_strength, la
         _js="submit_ltx",
         inputs=state_inputs + video_inputs,
         outputs=video_outputs,
-        show_progress=False,
+        show_progress='hidden',
     )
     generate.click(**video_dict)

--- a/modules/ui_common.py
+++ b/modules/ui_common.py
@@ -285,23 +285,23 @@ def create_output_panel(tabname, preview=True, prompt=None, height=None, transfe
             with gr.Group():
                 html_info = gr.HTML(elem_id=f'html_info_{tabname}', elem_classes="infotext", visible=False) # contains raw infotext as returned by wrapped call
                 html_info_formatted = gr.HTML(elem_id=f'html_info_formatted_{tabname}', elem_classes="infotext", visible=True) # contains html formatted infotext
-                html_info.change(fn=infotext_to_html, inputs=[html_info], outputs=[html_info_formatted], show_progress=False)
+                html_info.change(fn=infotext_to_html, inputs=[html_info], outputs=[html_info_formatted], show_progress='hidden')
                 html_log = gr.HTML(elem_id=f'html_log_{tabname}')
                 generation_info = gr.Textbox(visible=False, elem_id=f'generation_info_{tabname}')
                 generation_info_button = gr.Button(visible=False, elem_id=f"{tabname}_generation_info_button")
 
                 result_field = result_info or html_info_formatted
-                generation_info_button.click(fn=update_generation_info, show_progress=False,
+                generation_info_button.click(fn=update_generation_info, show_progress='hidden',
                     _js="(x, y, z) => [x, y, selected_gallery_index()]", # triggered on gallery change from js
                     inputs=[generation_info, html_info, html_info],
                     outputs=[html_info, result_field],
                 )
-                save.click(fn=call_queue.wrap_gradio_call(save_files), show_progress=False,
+                save.click(fn=call_queue.wrap_gradio_call(save_files), show_progress='hidden',
                     _js="(x, y, z, i) => [x, y, z, selected_gallery_index()]",
                     inputs=[generation_info, result_gallery, html_info, html_info],
                     outputs=[download_files, html_log],
                 )
-                delete.click(fn=call_queue.wrap_gradio_call(delete_files), show_progress=False,
+                delete.click(fn=call_queue.wrap_gradio_call(delete_files), show_progress='hidden',
                     _js="(x, y, i, j) => [x, y, ...selected_gallery_files()]",
                     inputs=[generation_info, result_gallery, html_info, html_info],
                     outputs=[result_gallery, html_log],
@@ -345,7 +345,7 @@ def create_refresh_button(refresh_component, refresh_method, refreshed_args = No
         return gr.update(**args)
 
     refresh_button = ui_components.ToolButton(value=ui_symbols.refresh, elem_id=elem_id, visible=visible)
-    refresh_button.click(fn=refresh, inputs=[], outputs=[refresh_component], show_progress=False)
+    refresh_button.click(fn=refresh, inputs=[], outputs=[refresh_component], show_progress='hidden')
     return refresh_button
 
 
@@ -374,7 +374,7 @@ def reuse_seed(seed_component: gr.Number, reuse_button: gr.Button, subseed:bool=
         shared.log.debug(f'Reuse seed: index={selected_gallery_index} seed={seed} subseed={subseed}')
         return seed
 
-    reuse_button.click(fn=reuse_click, _js="selected_gallery_index", inputs=[seed_component], outputs=[seed_component], show_progress=False)
+    reuse_button.click(fn=reuse_click, _js="selected_gallery_index", inputs=[seed_component], outputs=[seed_component], show_progress='hidden')
 
 
 def connect_reuse_seed(seed: gr.Number, reuse_seed_btn: gr.Button, generation_info: gr.Textbox, is_subseed, subseed_strength=None):
@@ -405,9 +405,9 @@ def connect_reuse_seed(seed: gr.Number, reuse_seed_btn: gr.Button, generation_in
             return [restore_seed, gr_show(False)]
     dummy_component = gr.Number(visible=False, value=0)
     if subseed_strength is None:
-        reuse_seed_btn.click(fn=copy_seed, _js="(x, y) => [x, selected_gallery_index()]", show_progress=False, inputs=[generation_info, dummy_component], outputs=[seed, dummy_component])
+        reuse_seed_btn.click(fn=copy_seed, _js="(x, y) => [x, selected_gallery_index()]", show_progress='hidden', inputs=[generation_info, dummy_component], outputs=[seed, dummy_component])
     else:
-        reuse_seed_btn.click(fn=copy_seed, _js="(x, y) => [x, selected_gallery_index()]", show_progress=False, inputs=[generation_info, dummy_component], outputs=[seed, dummy_component, subseed_strength])
+        reuse_seed_btn.click(fn=copy_seed, _js="(x, y) => [x, selected_gallery_index()]", show_progress='hidden', inputs=[generation_info, dummy_component], outputs=[seed, dummy_component, subseed_strength])
 
 
 def update_token_counter(text):

--- a/modules/ui_control.py
+++ b/modules/ui_control.py
@@ -243,20 +243,20 @@ def create_ui(_blocks: gr.Blocks=None):
             for u in units:
                 controls.extend(u.controls)
             btn_update = gr.Button('Update', interactive=True, visible=False, elem_id='control_update')
-            btn_update.click(fn=get_units, inputs=controls, outputs=[], show_progress=False, queue=False)
+            btn_update.click(fn=get_units, inputs=controls, outputs=[], show_progress='hidden', queue=False)
 
             show_input.change(fn=lambda x: gr.update(visible=x), inputs=[show_input], outputs=[column_input])
             show_preview.change(fn=lambda x: gr.update(visible=x), inputs=[show_preview], outputs=[column_preview])
             input_type.change(fn=lambda x: gr.update(visible=x == 2), inputs=[input_type], outputs=[column_init])
-            btn_prompt_counter.click(fn=call_queue.wrap_queued_call(ui_common.update_token_counter), inputs=[prompt], outputs=[prompt_counter], show_progress = False)
-            btn_negative_counter.click(fn=call_queue.wrap_queued_call(ui_common.update_token_counter), inputs=[negative], outputs=[negative_counter], show_progress = False)
+            btn_prompt_counter.click(fn=call_queue.wrap_queued_call(ui_common.update_token_counter), inputs=[prompt], outputs=[prompt_counter], show_progress = 'hidden')
+            btn_negative_counter.click(fn=call_queue.wrap_queued_call(ui_common.update_token_counter), inputs=[negative], outputs=[negative_counter], show_progress = 'hidden')
 
             select_dict = dict(
                 fn=helpers.select_input,
                 _js="controlInputMode",
                 inputs=[input_mode, input_image, init_image, input_type, input_video, input_batch, input_folder],
                 outputs=[output_tabs, preview_process, result_txt, width_before, height_before],
-                show_progress=False,
+                show_progress='hidden',
                 queue=False,
             )
 
@@ -305,7 +305,7 @@ def create_ui(_blocks: gr.Blocks=None):
                 _js="submit_control",
                 inputs=[tabs_state, state, tabs_state] + input_fields + input_script_args,
                 outputs=output_fields,
-                show_progress=True,
+                show_progress='full',
             )
             prompt.submit(**control_dict)
             negative.submit(**control_dict)

--- a/modules/ui_docs.py
+++ b/modules/ui_docs.py
@@ -242,7 +242,7 @@ def create_ui_logs():
         _changelog_result = gr.HTML(elem_id="changelog_result")
 
     changelog_markdown = gr.Markdown('', elem_id="changelog_markdown")
-    get_changelog_btn.click(fn=get_changelog, outputs=[changelog_markdown], show_progress=True)
+    get_changelog_btn.click(fn=get_changelog, outputs=[changelog_markdown], show_progress='full')
 
 
 def create_ui_github():
@@ -254,9 +254,9 @@ def create_ui_github():
     with gr.Row():
         github_md_btn = gr.Button(value='html2md', elem_id="github_md_btn", visible=False)
         github_md = gr.Markdown(elem_id="github_md", value='', elem_classes="github-md")
-    github_search.submit(fn=search_github, inputs=[github_search], outputs=[github_result], show_progress=True)
-    github_search_btn.click(fn=search_github, inputs=[github_search], outputs=[github_result], show_progress=True)
-    github_md_btn.click(fn=get_github_page, _js='getGitHubWikiPage', inputs=[github_search], outputs=[github_md], show_progress=True)
+    github_search.submit(fn=search_github, inputs=[github_search], outputs=[github_result], show_progress='full')
+    github_search_btn.click(fn=search_github, inputs=[github_search], outputs=[github_result], show_progress='full')
+    github_md_btn.click(fn=get_github_page, _js='getGitHubWikiPage', inputs=[github_search], outputs=[github_md], show_progress='full')
 
 
 def create_ui_docs():
@@ -268,10 +268,10 @@ def create_ui_docs():
     with gr.Row():
         docs_md_btn = gr.Button(value='html2md', elem_id="docs_md_btn", visible=False)
         docs_md = gr.Markdown(elem_id="docs_md", value='', elem_classes="docs-md")
-    docs_search.submit(fn=search_docs, inputs=[docs_search], outputs=[docs_result], show_progress=False)
-    docs_search.change(fn=search_docs, inputs=[docs_search], outputs=[docs_result], show_progress=False)
-    docs_search_btn.click(fn=search_docs, inputs=[docs_search], outputs=[docs_result], show_progress=False)
-    docs_md_btn.click(fn=get_docs_page, _js='getDocsPage', inputs=[docs_search], outputs=[docs_md], show_progress=False)
+    docs_search.submit(fn=search_docs, inputs=[docs_search], outputs=[docs_result], show_progress='hidden')
+    docs_search.change(fn=search_docs, inputs=[docs_search], outputs=[docs_result], show_progress='hidden')
+    docs_search_btn.click(fn=search_docs, inputs=[docs_search], outputs=[docs_result], show_progress='hidden')
+    docs_md_btn.click(fn=get_docs_page, _js='getDocsPage', inputs=[docs_search], outputs=[docs_md], show_progress='hidden')
 
 
 def create_ui():

--- a/modules/ui_history.py
+++ b/modules/ui_history.py
@@ -8,4 +8,4 @@ def create_ui():
         _history_table = gr.HTML('', elem_id='history_table')
     with gr.Row():
         _history_timeline = gr.HTML('', elem_id='history_timeline')
-    btn_refresh.click(_js='refreshHistory', fn=None, inputs=[], outputs=[], show_progress=False)
+    btn_refresh.click(_js='refreshHistory', fn=None, inputs=[], outputs=[], show_progress='hidden')

--- a/modules/ui_img2img.py
+++ b/modules/ui_img2img.py
@@ -203,7 +203,7 @@ def create_ui():
                     img2img_html_info,
                     img2img_html_log,
                 ],
-                show_progress=False,
+                show_progress='hidden',
             )
             img2img_prompt.submit(**img2img_dict)
             img2img_negative_prompt.submit(**img2img_dict)
@@ -229,8 +229,8 @@ def create_ui():
             )
             interrogate_btn.click(fn=lambda *args: process_interrogate(*args), **interrogate_args)
 
-            img2img_token_button.click(fn=call_queue.wrap_queued_call(ui_common.update_token_counter), inputs=[img2img_prompt], outputs=[img2img_token_counter], show_progress = False)
-            img2img_negative_token_button.click(fn=call_queue.wrap_queued_call(ui_common.update_token_counter), inputs=[img2img_negative_prompt], outputs=[img2img_negative_token_counter], show_progress = False)
+            img2img_token_button.click(fn=call_queue.wrap_queued_call(ui_common.update_token_counter), inputs=[img2img_prompt], outputs=[img2img_token_counter], show_progress = 'hidden')
+            img2img_negative_token_button.click(fn=call_queue.wrap_queued_call(ui_common.update_token_counter), inputs=[img2img_negative_prompt], outputs=[img2img_negative_token_counter], show_progress = 'hidden')
 
             ui_extra_networks.setup_ui(extra_networks_ui_img2img, img2img_gallery)
             img2img_paste_fields = [

--- a/modules/ui_models.py
+++ b/modules/ui_models.py
@@ -532,7 +532,7 @@ def create_ui():
                     _js="downloadCivitModel",
                     inputs=[_dummy, _dummy, _dummy, civit_folder, civit_token, civitai_models_output],
                     outputs=[civitai_models_output],
-                    show_progress=True,
+                    show_progress='full',
                 )
 
             with gr.Tab(label="Huggingface", elem_id="models_huggingface_tab"):

--- a/modules/ui_sections.py
+++ b/modules/ui_sections.py
@@ -45,7 +45,7 @@ def create_toprow(is_img2img: bool = False, id_part: str = None, generate_visibl
                 button_paste = gr.Button(value='Restore', variant='secondary', elem_id=f"{id_part}_paste") # symbols.paste
                 button_clear = gr.Button(value='Clear', variant='secondary', elem_id=f"{id_part}_clear_prompt_btn") # symbols.clear
                 button_extra = gr.Button(value='Networks', variant='secondary', elem_id=f"{id_part}_extra_networks_btn") # symbols.networks
-                button_clear.click(fn=lambda *x: ['', ''], inputs=[prompt, negative_prompt], outputs=[prompt, negative_prompt], show_progress=False)
+                button_clear.click(fn=lambda *x: ['', ''], inputs=[prompt, negative_prompt], outputs=[prompt, negative_prompt], show_progress='hidden')
             with gr.Row(elem_id=f"{id_part}_counters"):
                 token_counter = gr.HTML(value="<span>0/75</span>", elem_id=f"{id_part}_token_counter", elem_classes=["token-counter"], visible=False)
                 token_button = gr.Button(visible=False, elem_id=f"{id_part}_token_button")
@@ -57,9 +57,9 @@ def create_toprow(is_img2img: bool = False, id_part: str = None, generate_visibl
                 styles_btn_select = ToolButton('Select', elem_id=f"{id_part}_styles_select", visible=False)
                 styles_btn_apply = ToolButton(ui_symbols.style_apply, elem_id=f"{id_part}_styles_apply", visible=True)
                 styles_btn_save = ToolButton(ui_symbols.style_save, elem_id=f"{id_part}_styles_save", visible=True)
-                styles_btn_select.click(_js="applyStyles", fn=parse_style, inputs=[styles], outputs=[styles], show_progress=False)
-                styles_btn_apply.click(fn=apply_styles, inputs=[prompt, negative_prompt, styles], outputs=[prompt, negative_prompt, styles], show_progress=False)
-                styles_btn_save.click(fn=lambda: None, _js='() => quickSaveStyle()', inputs=[], outputs=[], show_progress=False)
+                styles_btn_select.click(_js="applyStyles", fn=parse_style, inputs=[styles], outputs=[styles], show_progress='hidden')
+                styles_btn_apply.click(fn=apply_styles, inputs=[prompt, negative_prompt, styles], outputs=[prompt, negative_prompt, styles], show_progress='hidden')
+                styles_btn_save.click(fn=lambda: None, _js='() => quickSaveStyle()', inputs=[], outputs=[], show_progress='hidden')
     return prompt, styles, negative_prompt, submit, reprocess, button_paste, button_extra, token_counter, token_button, negative_token_counter, negative_token_button
 
 
@@ -85,9 +85,9 @@ def create_resolution_inputs(tab, default_width=1024, default_height=1024):
     ar_list = ['AR'] + [x.strip() for x in shared.opts.aspect_ratios.split(',') if x.strip() != '']
     ar_dropdown = gr.Dropdown(show_label=False, interactive=True, choices=ar_list, value=ar_list[0], elem_id=f"{tab}_ar", elem_classes=["ar-dropdown"])
     for c in [ar_dropdown, width, height]:
-        c.change(fn=ar_change, inputs=[ar_dropdown, width, height], outputs=[width, height], show_progress=False)
+        c.change(fn=ar_change, inputs=[ar_dropdown, width, height], outputs=[width, height], show_progress='hidden')
     res_switch_btn = ToolButton(value=ui_symbols.switch, elem_id=f"{tab}_res_btn_swap")
-    res_switch_btn.click(lambda w, h: (h, w), inputs=[width, height], outputs=[width, height], show_progress=False)
+    res_switch_btn.click(lambda w, h: (h, w), inputs=[width, height], outputs=[width, height], show_progress='hidden')
     return width, height
 
 
@@ -120,8 +120,8 @@ def create_seed_inputs(tab, reuse_visible=True, accordion=True, subseed_visible=
         with gr.Row(visible=seed_resize_visible):
             seed_resize_from_w = gr.Slider(minimum=0, maximum=4096, step=8, label="Resize seed from width", value=0, elem_id=f"{tab}_seed_resize_from_w")
             seed_resize_from_h = gr.Slider(minimum=0, maximum=4096, step=8, label="Resize seed from height", value=0, elem_id=f"{tab}_seed_resize_from_h")
-        random_seed.click(fn=lambda: -1, show_progress=False, inputs=[], outputs=[seed])
-        random_subseed.click(fn=lambda: -1, show_progress=False, inputs=[], outputs=[subseed])
+        random_seed.click(fn=lambda: -1, show_progress='hidden', inputs=[], outputs=[seed])
+        random_subseed.click(fn=lambda: -1, show_progress='hidden', inputs=[], outputs=[subseed])
     return seed, reuse_seed, subseed, reuse_subseed, subseed_strength, seed_resize_from_h, seed_resize_from_w
 
 
@@ -351,17 +351,17 @@ def create_resize_inputs(tab, images, accordion=True, latent=False, non_zero=Tru
                                 ar_list = ['AR'] + [x.strip() for x in shared.opts.aspect_ratios.split(',') if x.strip() != '']
                                 ar_dropdown = gr.Dropdown(show_label=False, interactive=True, choices=ar_list, value=ar_list[0], elem_id=f"{tab}_resize_ar", elem_classes=["ar-dropdown"])
                                 for c in [ar_dropdown, width, height]:
-                                    c.change(fn=ar_change, inputs=[ar_dropdown, width, height], outputs=[width, height], show_progress=False)
+                                    c.change(fn=ar_change, inputs=[ar_dropdown, width, height], outputs=[width, height], show_progress='hidden')
                                 res_switch_btn = ToolButton(value=ui_symbols.switch, elem_id=f"{tab}_resize_size_swap")
-                                res_switch_btn.click(lambda w, h: (h, w), inputs=[width, height], outputs=[width, height], show_progress=False)
+                                res_switch_btn.click(lambda w, h: (h, w), inputs=[width, height], outputs=[width, height], show_progress='hidden')
                                 detect_image_size_btn = ToolButton(value=ui_symbols.detect, elem_id=f"{tab}_resize_detect_size")
                                 el = tab.split('_')[0]
-                                detect_image_size_btn.click(fn=lambda w, h, _: (w or gr.update(), h or gr.update()), _js=f'currentImageResolution{el}', inputs=[dummy_component, dummy_component, dummy_component], outputs=[width, height], show_progress=False)
+                                detect_image_size_btn.click(fn=lambda w, h, _: (w or gr.update(), h or gr.update()), _js=f'currentImageResolution{el}', inputs=[dummy_component, dummy_component, dummy_component], outputs=[width, height], show_progress='hidden')
                     with gr.Tab(label="Scale", id=1, elem_id=f"{tab}_scale_tab_scale") as tab_scale_by:
                         scale_by = gr.Slider(minimum=0.05, maximum=8.0, step=0.05, label=f"Scale{prefix}" if non_zero else "Resize scale", value=1.0, elem_id=f"{tab}_scale")
                     if images is not None:
                         for component in images:
-                            component.change(fn=lambda: None, _js="updateImg2imgResizeToTextAfterChangingImage", inputs=[], outputs=[], show_progress=False)
+                            component.change(fn=lambda: None, _js="updateImg2imgResizeToTextAfterChangingImage", inputs=[], outputs=[], show_progress='hidden')
             tab_scale_to.select(fn=lambda: 0, inputs=[], outputs=[selected_scale_tab])
             tab_scale_by.select(fn=lambda: 1, inputs=[], outputs=[selected_scale_tab])
             # resize_mode.change(fn=lambda x: gr.update(visible=x != 0), inputs=[resize_mode], outputs=[_resize_group])

--- a/modules/ui_settings.py
+++ b/modules/ui_settings.py
@@ -100,7 +100,7 @@ def create_setting_component(key, is_quicksettings=False):
         except Exception as e:
             shared.log.error(f'Quicksetting: component={res} {e}')
         if dirty_indicator is not None:
-            dirty_indicator.click(fn=lambda: shared.opts.get_default(key), outputs=[res], show_progress=False)
+            dirty_indicator.click(fn=lambda: shared.opts.get_default(key), outputs=[res], show_progress='hidden')
         dirtyable_setting.__exit__()
 
     return res
@@ -113,7 +113,7 @@ def create_dirty_indicator(key, keys_to_reset, **kwargs):
 
     elements_to_reset = [shared.settings_components[_key] for _key in keys_to_reset if shared.settings_components[_key] is not None]
     indicator = gr.Button('', elem_classes="modification-indicator", elem_id=f"modification_indicator_{key}", **kwargs)
-    indicator.click(fn=get_default_values, outputs=elements_to_reset, show_progress=True)
+    indicator.click(fn=get_default_values, outputs=elements_to_reset, show_progress='full')
     return indicator
 
 
@@ -369,7 +369,7 @@ def create_quicksettings(interfaces):
                     fn=lambda value, k=k, progress=info.refresh is not None: run_settings_single(value, key=k, progress=progress),
                     inputs=[component],
                     outputs=[component, text_settings],
-                    show_progress=info.refresh is not None,
+                    show_progress='full' if info.refresh is not None else 'hidden',
                 )
 
         button_set_checkpoint = gr.Button('Change model', elem_id='change_checkpoint', visible=False)

--- a/modules/ui_txt2img.py
+++ b/modules/ui_txt2img.py
@@ -77,7 +77,7 @@ def create_ui():
                     txt2img_html_info,
                     txt2img_html_log,
                 ],
-                show_progress=False,
+                show_progress='hidden',
             )
 
             txt2img_prompt.submit(**txt2img_dict)
@@ -160,7 +160,7 @@ def create_ui():
             txt2img_bindings = generation_parameters_copypaste.ParamBinding(paste_button=txt2img_paste, tabname="txt2img", source_text_component=txt2img_prompt, source_image_component=None)
             generation_parameters_copypaste.register_paste_params_button(txt2img_bindings)
 
-            txt2img_token_button.click(fn=call_queue.wrap_queued_call(ui_common.update_token_counter), inputs=[txt2img_prompt], outputs=[txt2img_token_counter], show_progress = False)
-            txt2img_negative_token_button.click(fn=call_queue.wrap_queued_call(ui_common.update_token_counter), inputs=[txt2img_negative_prompt], outputs=[txt2img_negative_token_counter], show_progress = False)
+            txt2img_token_button.click(fn=call_queue.wrap_queued_call(ui_common.update_token_counter), inputs=[txt2img_prompt], outputs=[txt2img_token_counter], show_progress = 'hidden')
+            txt2img_negative_token_button.click(fn=call_queue.wrap_queued_call(ui_common.update_token_counter), inputs=[txt2img_negative_prompt], outputs=[txt2img_negative_token_counter], show_progress = 'hidden')
 
             ui_extra_networks.setup_ui(extra_networks_ui, txt2img_gallery)

--- a/modules/ui_video_vlm.py
+++ b/modules/ui_video_vlm.py
@@ -65,6 +65,6 @@ def create_ui(prompt_element:gr.Textbox, image_element:gr.Image):
             fn=enhance_prompt,
             inputs=[enable, model, image_element, prompt_element, system_prompt, nsfw],
             outputs=prompt_element,
-            show_progress=True,
+            show_progress='full',
         )
     return enable, model, system_prompt

--- a/modules/video_models/video_ui.py
+++ b/modules/video_models/video_ui.py
@@ -116,7 +116,7 @@ def create_ui_size():
                 seed = gr.Number(label='Initial seed', value=-1, elem_id="video_seed", container=True)
                 random_seed = ToolButton(ui_symbols.random, elem_id="video_seed_random")
                 reuse_seed = ToolButton(ui_symbols.reuse, elem_id="video_seed_reuse")
-                random_seed.click(fn=lambda: -1, show_progress=False, inputs=[], outputs=[seed])
+                random_seed.click(fn=lambda: -1, show_progress='hidden', inputs=[], outputs=[seed])
     return width, height, frames, seed, reuse_seed
 
 
@@ -194,7 +194,7 @@ def create_ui(prompt, negative, styles, overrides, init_image, init_strength, la
         _js="submit_video",
         inputs=state_inputs + video_inputs,
         outputs=video_outputs,
-        show_progress=False,
+        show_progress='hidden',
     )
     generate.click(**video_dict)
     return [engine, model, steps, sampler_index]

--- a/scripts/postprocessing_upscale.py
+++ b/scripts/postprocessing_upscale.py
@@ -33,7 +33,7 @@ class ScriptPostprocessingUpscale(scripts_postprocessing.ScriptPostprocessing):
                     extras_upscaler_2 = gr.Dropdown(label='Refine upscaler', elem_id="extras_upscaler_2", choices=[x.name for x in shared.sd_upscalers], value=shared.sd_upscalers[0].name)
                     extras_upscaler_2_visibility = gr.Slider(minimum=0.0, maximum=1.0, step=0.001, label="Blend strength", value=0.0, elem_id="extras_upscaler_2_visibility")
 
-            upscaling_res_switch_btn.click(lambda w, h: (h, w), inputs=[upscaling_resize_w, upscaling_resize_h], outputs=[upscaling_resize_w, upscaling_resize_h], show_progress=False)
+            upscaling_res_switch_btn.click(lambda w, h: (h, w), inputs=[upscaling_resize_w, upscaling_resize_h], outputs=[upscaling_resize_w, upscaling_resize_h], show_progress='hidden')
             tab_scale_by.select(fn=lambda: 0, inputs=[], outputs=[selected_tab])
             tab_scale_to.select(fn=lambda: 1, inputs=[], outputs=[selected_tab])
 

--- a/scripts/prompts_from_file.py
+++ b/scripts/prompts_from_file.py
@@ -105,8 +105,8 @@ class Script(scripts_manager.Script):
             checkbox_iterate_batch = gr.Checkbox(label="Use same seed", value=False, elem_id=self.elem_id("checkbox_iterate_batch"))
         prompt_txt = gr.Textbox(label="Prompts", lines=2, elem_id=self.elem_id("prompt_txt"), value='')
         file = gr.File(label="Upload prompts", type='binary', elem_id=self.elem_id("file"))
-        file.change(fn=load_prompt_file, inputs=[file], outputs=[file, prompt_txt, prompt_txt], show_progress=False)
-        prompt_txt.change(lambda tb: gr.update(lines=7) if ("\n" in tb) else gr.update(lines=2), inputs=[prompt_txt], outputs=[prompt_txt], show_progress=False)
+        file.change(fn=load_prompt_file, inputs=[file], outputs=[file, prompt_txt, prompt_txt], show_progress='hidden')
+        prompt_txt.change(lambda tb: gr.update(lines=7) if ("\n" in tb) else gr.update(lines=2), inputs=[prompt_txt], outputs=[prompt_txt], show_progress='hidden')
         return [checkbox_iterate, checkbox_iterate_batch, prompt_txt]
 
     def run(self, p, checkbox_iterate, checkbox_iterate_batch, prompt_txt: str): # pylint: disable=arguments-differ


### PR DESCRIPTION
Fixes all instances of the `show_progress` argument. They were being treated as `bool`, but the actual accepted options set is `Literal['full', 'minimal', 'hidden']`.

~~This would often show up in logs as a warning with "ui mismatch".~~

If you find anything that doesn't look right in the UI, you can try setting it to `'minimal'` instead of `'full'`.