### PR TITLE
Update runai-model-streamer logging integration

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -1392,6 +1392,7 @@ def set_environment():
     os.environ.setdefault('UVICORN_TIMEOUT_KEEP_ALIVE', '60')
     os.environ.setdefault('RUNAI_STREAMER_CHUNK_BYTESIZE', '2097152')
     os.environ.setdefault('RUNAI_STREAMER_MEMORY_LIMIT', '-1')
+    os.environ.setdefault('RUNAI_STREAMER_LOG_LEVEL', 'DEBUG' if os.environ.get('SD_LOAD_DEBUG') else 'WARNING')
     allocator = f'garbage_collection_threshold:{opts.get("torch_gc_threshold", 80)/100:0.2f},max_split_size_mb:512'
     if opts.get("torch_malloc", "native") == 'cudaMallocAsync':
         allocator += ',backend:cudaMallocAsync'

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -65,6 +65,8 @@ def set_huggingface_options():
     else:
         sd_hijack_accelerate.restore_accelerate()
     if (shared.opts.runai_streamer_diffusers or shared.opts.runai_streamer_transformers) and (sys.platform == 'linux'):
+        import os
+        log.debug(f'Loader: runai enabled chunk={os.environ["RUNAI_STREAMER_CHUNK_BYTESIZE"]} limit={os.environ["RUNAI_STREAMER_MEMORY_LIMIT"]}')
         sd_hijack_safetensors.hijack_safetensors(shared.opts.runai_streamer_diffusers, shared.opts.runai_streamer_transformers)
     else:
         sd_hijack_safetensors.restore_safetensors()
@@ -629,8 +631,7 @@ def load_sdnq_model(checkpoint_info, pipeline, diffusers_load_config, op):
     if shared.opts.runai_streamer_diffusers and (sys.platform == 'linux'):
         load_method = 'streamer'
         from installer import install
-        install('runai_model_streamer')
-        shared.log.trace(f'Loader: method={load_method} chunk={os.environ["RUNAI_STREAMER_CHUNK_BYTESIZE"]} limit={os.environ["RUNAI_STREAMER_MEMORY_LIMIT"]}')
+        install('runai_model_streamer>=0.15.1')
     elif shared.opts.sd_parallel_load:
         load_method = 'threaded'
     else:


### PR DESCRIPTION
- Remove stdout redirect monkeypatch (fixed in runai v0.15.1)
- Add RUNAI_STREAMER_LOG_LEVEL controlled by SD_LOAD_DEBUG
- Add one-time runai config log when hijack is activated
- Add `loader=runai|default` to model loading logs
- Remove per-file logging clutter from sd_hijack_safetensors.py

Improving logging of other models like prompt enhancer and VQA was omitted deliberately awaiting the VQA and subsequent PRs.
