### PR TITLE
fix(processing): convert vae_decode results to list in process_decode

### DIFF
--- a/modules/processing_diffusers.py
+++ b/modules/processing_diffusers.py
@@ -477,6 +477,8 @@ def process_decode(p: processing.StableDiffusionProcessing, output):
                     height = height,
                     frames = frames,
                 )
+                if not isinstance(results, list):
+                    results = list(results)
         elif hasattr(output, 'images'):
             results = output.images
         else:


### PR DESCRIPTION
The else branch in process_decode was returning a numpy array directly from vae_decode, while the if branch properly converted results to a list. This caused process_samples to return early with an empty infotext list, and zip(numpy_array, []) produced zero iterations, resulting in images=0 for detailer, inpainting, and img2img operations.

Bug introduced in 3e8dec929 (Dec 2024), exposed by 63a180be1 (Nov 2025).