### PR TITLE
Add warning messages on type mismatch and fix default

### DIFF
--- a/modules/json_helpers.py
+++ b/modules/json_helpers.py
@@ -59,17 +59,17 @@ def readfile(filename: str, silent: bool = False, lock: bool = False, *, as_type
     except Exception:
         locking_available = False
     if isinstance(data, list) and as_type == "dict":
-        log.warning(f"Read: Expected dictionary from '{filename}' but got list")
         if not data:
             return {}
+        log.warning(f"Read: Expected dictionary from '{filename}' but got list")
         data0 = data[0]
         if isinstance(data0, dict):
             return data0
         return {}
     if isinstance(data, dict) and as_type == "list":
-        log.warning(f"Read: Expected list from '{filename}' but got dictionary")
         if not data:
             return []
+        log.warning(f"Read: Expected list from '{filename}' but got dictionary")
         return [data]
     return data
 


### PR DESCRIPTION
Warn when there's a mismatch between the expected data format and the read data format.