### PR TITLE
Fix Wan missing frames on first generation

### DIFF
--- a/modules/sd_offload.py
+++ b/modules/sd_offload.py
@@ -254,10 +254,12 @@ class OffloadHook(accelerate.hooks.ModelHook):
             if debug:
                 shared.log.trace(f'Offload: type=balanced op=dispatch map={device_map}')
             if device_map is not None:
+                skip_keys = getattr(module, "_skip_keys", None)
                 module = accelerate.dispatch_model(module,
                                                    main_device=torch.device(devices.device),
                                                    device_map=device_map,
                                                    offload_dir=offload_dir,
+                                                   skip_keys=skip_keys,
                                                    force_hooks=True,
                                                   )
             module._hf_hook.execution_device = torch.device(devices.device) # pylint: disable=protected-access


### PR DESCRIPTION
## Description

Work around the missing Wan frames issues. Resolves #4526.

## Notes
This change passes the model’s `_skip_keys` to `accelerate.dispatch_model`, preventing Accelerate from moving/cloning the WAN VAE’s mutable cache kwargs (`feat_idx`/`feat_cache`). Before this, those list objects were cloned, so each VAE module would get its own copy, which it mutates in place, thus never sharing/accumulating the state as the frames were expanded temporally, resulting in the output frame count being equal to the latent frame count `(floor((num_frames - 1) / 4) + 1`, e.g. 17 → 5).

It's not 100% clear to me why this only happened on the first generation, but it seems to be related to "cold" vs "hot" code paths -- after the first generation, the model is already on the GPU, so it doesn't need to exercise the offload hooks in the same way for subsequent generations.

I intend to submit a PR to Diffusers to fix this behavior internally, so if and when that is accepted, this change to SDNext will no longer be necessary.

## Environment and Testing
Fedora Linux
