### PR TITLE
fix(control): ensure state cleanup runs reliably

### DIFF
--- a/modules/ui_control.py
+++ b/modules/ui_control.py
@@ -269,6 +269,7 @@ def create_ui(_blocks: gr.Blocks=None):
 
             prompt.submit(**select_dict)
             negative.submit(**select_dict)
+            btn_generate.click(**select_dict)
             for ctrl in [input_image, input_video, input_batch, input_folder, init_image, init_video, init_batch, init_folder, tab_image, tab_video, tab_batch, tab_folder, tab_image_init, tab_video_init, tab_batch_init, tab_folder_init]:
                 if hasattr(ctrl, 'change'):
                     ctrl.change(**select_dict)


### PR DESCRIPTION
## Description

I've been chasing this since forever, with renewed interest ever since rolling out Google-image-pro on my instances, where SDNext was unusable, as the tab needed a refresh after every single generation.
I've chased it as far as I can, tested with multiple instances, fixed the issues I was having with both long running tasks like Grids and the recent problem when used with Google models.

Fix control tab getting stuck in running state after generation completes. Closes #4281 

## Notes

So far what I managed to find out regarding root causes:

1. Code after `yield` in generators only executes when the generator is fully consumed. With long generations or remote models, Gradio may stop consuming early (timeout, disconnect), leaving cleanup code unexecuted.

2. The redundant state.begin('UI') wrapper in control_run() was unreliable because the state.end() after yield often didn't run.

3. Having two separate `.click()` handlers on btn_generate (select_dict and control_dict) caused Gradio to not reliably fire both handlers.

Changes:
- Remove state.begin('UI')/state.end() wrapper from control_run() - the state management is already done properly in generate_click()
- Add GeneratorExit handling in generate_click() to catch when the generator is closed prematurely by the client
- Move progress.finish_task() and state.end() into a finally block to guarantee cleanup runs regardless of how the generator terminates
- Remove redundant select_dict handler from btn_generate - input selection already happens via change handlers on all input controls

## Environment and Testing

OS: Windows 11 (WSL2 Ubuntu 22.04)
Python: 3.12

Mobile: Samsung S25 Ultra
