### PR TITLE
Fix gallery next/prev buttons

### DIFF
--- a/javascript/imageViewer.js
+++ b/javascript/imageViewer.js
@@ -53,15 +53,15 @@ function modalImageSwitch(offset) {
 
   const galleryFilesContainer = gradioApp().getElementById('tab-gallery-files');
   if (!galleryFilesContainer || !galleryFilesContainer.offsetParent) return;
-  const gallerySelection = window.getGallerySelection?.();
-  if (!gallerySelection?.files?.length || gallerySelection.files.length <= 1) return;
+  const gallerySelection = window.getGallerySelection();
+  if (!gallerySelection.files.length || gallerySelection.files.length <= 1) return;
   const baseIndex = gallerySelection.index >= 0 ? gallerySelection.index : 0;
   const nextIndex = negmod((baseIndex + offset), gallerySelection.files.length);
-  window.setGallerySelection?.(nextIndex, { send: true, emit: true });
+  window.setGallerySelection(nextIndex, { send: true });
   const modalImage = gradioApp().getElementById('modalImage');
   const modal = gradioApp().getElementById('lightboxModal');
-  const directSrc = window.getGallerySelectedUrl?.() || new URL(`/file=${encodeURI(window.currentImage)}`, window.location.origin).toString();
-  if (modalImage && modal) {
+  const directSrc = window.getGallerySelectedUrl();
+  if (modalImage && modal && directSrc) {
     modalImage.src = directSrc;
     if (modalImage.style.display === 'none') modal.style.setProperty('background-image', `url(${directSrc})`);
   }

--- a/javascript/ui.js
+++ b/javascript/ui.js
@@ -64,8 +64,8 @@ function selected_gallery_index() {
   let result = -1;
   buttons.forEach((v, i) => { if (v === button) { result = i; } });
   if (result === -1 && gradioApp().getElementById('tab-gallery-search')?.checkVisibility()) {
-    const gallerySelection = window.getGallerySelection?.();
-    if (gallerySelection && Number.isInteger(gallerySelection.index)) result = gallerySelection.index;
+    const gallerySelection = window.getGallerySelection();
+    if (Number.isInteger(gallerySelection.index)) result = gallerySelection.index;
   }
   return result;
 }


### PR DESCRIPTION
## Description

The next/prev buttons have been broken in the gallery view for a long time, so I fixed them. The next/prev controls already worked when you have multiple images generated in the other views, so I expanded the implementation of the gallery to produce the same events that the multi image view thing uses. I'm not 100% sure this is the best way to fix it, but it works. This also allows using the left/right arrow keys, and I took the liberty of adding an indicator to the gallery to show which image is the selected one.

## Environment and Testing

Fedora Linux, Chrome 143.0.7499.192