### PR TITLE
Expand TAESD previews to a few more models

### DIFF
--- a/modules/sd_vae_taesd.py
+++ b/modules/sd_vae_taesd.py
@@ -38,7 +38,7 @@ prev_cls = ''
 prev_type = ''
 prev_model = ''
 lock = threading.Lock()
-supported = ['sd', 'sdxl', 'sd3', 'f1', 'h1', 'z_image', 'lumina2', 'hunyuanvideo', 'wanai', 'chrono', 'cosmos', 'mochivideo', 'pixartsigma', 'pixartalpha', 'hunyuandit', 'omnigen', 'qwen', 'longcat', 'omnigen2', 'flite', 'ovis', 'kandinsky5', 'glmimage', 'cogview3', 'cogview4']
+supported = ['sd', 'sdxl', 'sd3', 'f1', 'h1', 'zimage', 'lumina2', 'hunyuanvideo', 'wanai', 'chrono', 'cosmos', 'mochivideo', 'pixartsigma', 'pixartalpha', 'hunyuandit', 'omnigen', 'qwen', 'longcat', 'omnigen2', 'flite', 'ovis', 'kandinsky5', 'glmimage', 'cogview3', 'cogview4']
 
 
 def warn_once(msg, variant=None):
@@ -59,7 +59,7 @@ def get_model(model_type = 'decoder', variant = None):
         model_cls = 'sd'
     elif model_cls in {'pixartsigma', 'hunyuandit', 'omnigen', 'auraflow'}:
         model_cls = 'sdxl'
-    elif model_cls in {'h1', 'z_image', 'lumina2', 'chroma', 'longcat', 'omnigen2', 'flite', 'ovis', 'kandinsky5', 'glmimage', 'cogview3', 'cogview4'}:
+    elif model_cls in {'h1', 'zimage', 'lumina2', 'chroma', 'longcat', 'omnigen2', 'flite', 'ovis', 'kandinsky5', 'glmimage', 'cogview3', 'cogview4'}:
         model_cls = 'f1'
     elif model_cls in {'wanai', 'qwen', 'chrono', 'cosmos'}:
         variant = variant or 'TAE WanVideo'


### PR DESCRIPTION
## Description

Add TAESD previews for:
- Cosmos predict2
- Omnigen 2
- Ovis Image
- F-Lite

## Notes

TAESD can be also expanded to Kandinsky 5 Image, but it seems that both K5 image and video use 'kandinsky5' which can cause problems. Also, it has been reported that Flux VAE preview can be used as a makeshift CogView VAE preview, allowing to expand preview functionality to CogView models

## Environment and Testing

Local
