### PR TITLE
fix(ui): improve gallery sorting and IndexedDB operations

### DIFF
--- a/javascript/indexdb.js
+++ b/javascript/indexdb.js
@@ -150,7 +150,10 @@ async function idbFolderCleanup(keepSet, folder, signal) {
     throw new Error('IndexedDB cleaning function must be told the current active folder');
   }
 
-  let removals = new Set(await idbGetAllKeys('folder', folder));
+  // Use range query to match folder and all its subdirectories
+  const folderNormalized = folder.replace(/\/+/g, '/').replace(/\/$/, '');
+  const range = IDBKeyRange.bound(folderNormalized, `${folderNormalized}\uffff`, false, true);
+  let removals = new Set(await idbGetAllKeys('folder', range));
   removals = removals.difference(keepSet); // Don't need to keep full set in memory
   const totalRemovals = removals.size;
   if (signal.aborted) {


### PR DESCRIPTION
##Description

Fixes gallery sorting behavior so that files are sorted within their respective folder groups rather than being mixed across directories making a layer cake of images in between duplicates of dividers. Root-level files now consistently appear at the top, with subfolder contents grouped and sorted below them. Also fixes cache hash consistency issues that caused duplicate thumbnails or missed cache hits when accessing the same file from different folder views.

##Notes

Sorting behavior changes:
- Root files (no directory path) are always displayed first, sorted according to the selected sort mode
- Subfolder files are grouped by directory, with folders sorted alphabetically. This is a compromise for an app like this, normally sorting by size in a folder would sort files and the subfolders *in their entirety*, i.e. size of the entire folder. But I don't see a point of ever sorting the dividers, you'd just start playing Where's Waldo after every sorting.
- Files within each folder are then sorted by the selected mode (name, size, resolution, modified date)

Misc
- The first folder separator now only auto-opens if there are no root files to display

Hash calculation fix:
- Previously used folder/name/size/mtime which produced different hashes for the same file when accessed via different folder views, now uses the normalized full src path, ensuring consistent cache hits regardless of which folder the gallery is browsed from. You can get your entire gallery indexed by opening the Base image folder, and the cache will be valid for subfolders too, like text or image.

IndexedDB cleanup fix:
- idbFolderCleanup now uses an IDBKeyRange bound query to match the folder and all its subdirectories. Previously only matched exact folder, leaving orphaned cache entries for nested files

##Environment and Testing

- Linux (WSL2)
- Modern UI
- Tested with nested folder structures containing mixed root and subfolder images