### PR TITLE
fix(ui): handle null description in network info JSON

### DIFF
--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -521,7 +521,7 @@ class ExtraNetworksPage:
         if not isinstance(info, dict):
             self.desc_time += time.time() - t0
             return ''
-        desc = info.get('description', '')
+        desc = info.get('description', '') or ''
         f = HTMLFilter()
         f.feed(desc)
         t1 = time.time()


### PR DESCRIPTION
## Description

When a LoRA info JSON file has `"description": null`, dict.get() returns None instead of the default empty string. This None value was passed to HTMLParser.feed() which fails on string concatenation.