### PR TITLE
Fix rocm triton windows patch

### DIFF
--- a/modules/rocm_triton_windows.py
+++ b/modules/rocm_triton_windows.py
@@ -59,7 +59,7 @@ if sys.platform == "win32":
         return zluda.core.to_hip_stream(_cuda_getCurrentRawStream(device))
 
     def get_default_agent() -> Union[Agent, None]:
-        if shared.devices.backend == "rocm":
+        if shared.devices.has_rocm():
             return devices.get_hip_agent()
         else:
             from modules import zluda


### PR DESCRIPTION
## Description
Because the call location of `apply_triton_patches()` was changed in commit https://github.com/vladmandic/sdnext/commit/9195116e4663c778aecef77c80b14f6cdb6ebadc , and `shared.devices.backend` was not yet available at the time of the call, cause `agent.name` could not be obtained.

This fixes `error: unsupported target: 'gfx0000'`.

## Notes
I'm not sure why patching triton is necessary. When I tested it, I simply removed the call to `apply_triton_patches()` and the triton test still passed, and `Triton Flash attention` also seemed to work correctly.

## Environment and Testing
Windows 11 25H2
AMD Radeon RX 9070 XT (Driver 25.12.1)
rocm 7.11.0a20260119
torch 2.9.1+rocm7.11.0a20260119
triton-windows 3.5.1.post24