### PR TITLE
Qwen layered settings typo

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -199,7 +199,7 @@ options_templates.update(options_section(('model_options', "Model Options"), {
     "model_wan_boundary": OptionInfo(0.85, "Stage boundary ratio", gr.Slider, {"minimum": 0, "maximum": 1.0, "step": 0.05 }),
     "model_chrono_sep": OptionInfo("<h2>ChronoEdit</h2>", "", gr.HTML),
     "model_chrono_temporal_steps": OptionInfo(0, "Temporal steps", gr.Slider, {"minimum": 0, "maximum": 50, "step": 1 }),
-    "model_qwen_layer_sep": OptionInfo("<h2>WanAI</h2>", "", gr.HTML),
+    "model_qwen_layer_sep": OptionInfo("<h2>Qwen layered</h2>", "", gr.HTML),
     "model_qwen_layers": OptionInfo(2, "Qwen layered number of layers", gr.Slider, {"minimum": 2, "maximum": 9, "step": 1 }),
 }))
 


### PR DESCRIPTION
## Description

<img width="541" height="107" alt="2026-01-21_211425" src="https://github.com/user-attachments/assets/6cb7a8cf-c63e-4872-8531-f273b1c35334" />

That looks wrong. just trying to fix.

## Notes

Minor typo fix

## Environment and Testing

w/o test
