### PR TITLE
fix elem_ids for some video controls

### DIFF
--- a/modules/ltx/ltx_ui.py
+++ b/modules/ltx/ltx_ui.py
@@ -15,7 +15,7 @@ def create_ui(prompt, negative, styles, overrides, init_image, init_strength, la
                 generate = gr.Button('Generate', elem_id="ltx_generate_btn", variant='primary', visible=False)
             with gr.Row():
                 ltx_models = [m.name for m in models['LTX Video']] if 'LTX Video' in models else ['None']
-                model = gr.Dropdown(label='LTX model', choices=ltx_models, value=ltx_models[0])
+                model = gr.Dropdown(label='LTX model', choices=ltx_models, value=ltx_models[0], elem_id="ltx_model")
             with gr.Accordion(open=False, label="Condition", elem_id='ltx_condition_accordion'):
                 with gr.Tabs():
                     with gr.Tab('Video', id='ltx_condition_video_tab'):

--- a/modules/video_models/video_ui.py
+++ b/modules/video_models/video_ui.py
@@ -98,7 +98,7 @@ def create_ui_outputs():
                 mp4_codec = gr.Dropdown(label="Video codec", choices=['none', 'libx264'], value='libx264', type='value')
                 ui_common.create_refresh_button(mp4_codec, video_utils.get_codecs, elem_id="framepack_mp4_codec_refresh")
                 mp4_ext = gr.Textbox(label="Video format", value='mp4', elem_id="framepack_mp4_ext")
-                mp4_opt = gr.Textbox(label="Video options", value='crf:16', elem_id="framepack_mp4_ext")
+                mp4_opt = gr.Textbox(label="Video options", value='crf:16', elem_id="framepack_mp4_opt")
             with gr.Row():
                 mp4_video = gr.Checkbox(label='Video save video', value=True, elem_id="framepack_mp4_video")
                 mp4_frames = gr.Checkbox(label='Video save frames', value=False, elem_id="framepack_mp4_frames")


### PR DESCRIPTION
The "Video format" and "Video options" textboxes had the same elem_id (both `framepack_mp4_ext`), and the "LTX model" dropdown didn't have an elem_id at all.

## Notes

Unique and correct element IDs are necessary for my work on the sdnext-scheduler to add enqueue for video generation.

## Environment and Testing

Fedora Kinoite 43, Chrome