### PR TITLE
[ROCM] Expand available gfx archs

### DIFF
--- a/modules/rocm.py
+++ b/modules/rocm.py
@@ -129,7 +129,9 @@ class Agent:
             return "v2-staging/gfx1152"
         if self.gfx_version == 0x1153:
             return "v2-staging/gfx1153"
-        if (self.gfx_version & 0xFFF0) == 0x1030:
+        if self.gfx_version == 0x1030:
+            return "v2-staging/gfx103X-dgpu"
+        if self.gfx_version == 0x1032:
             return "v2-staging/gfx103X-dgpu"
         #if (self.gfx_version & 0xFFF0) == 0x1010:
         #    return "gfx101X-dgpu"


### PR DESCRIPTION
## Description

Add AMD GFX archs that have available torch packages

## Notes

AMD has finally enabled TheRock packages for RDNA2 (gfx103x-dgpu), Kraken Point (gfx1152), Medusa Point (gfx1153). For now on the v2-staging folder