### PR TITLE
fix img2img api pipeline switch

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -1202,6 +1202,8 @@ def set_diffuser_pipe(pipe, new_pipe_type):
             else:
                 shared.log.warning(f'Pipeline class change failed: type={new_pipe_type} pipeline={cls}')
                 return pipe
+            if new_pipe is not None and hasattr(pipe, 'device'):
+                move_model(new_pipe, pipe.device)
         except Exception as e: # pylint: disable=unused-variable
             fn = f'{sys._getframe(2).f_code.co_name}:{sys._getframe(1).f_code.co_name}' # pylint: disable=protected-access
             shared.log.trace(f"Pipeline class change requested: target={new_pipe_type} fn={fn}") # pylint: disable=protected-access
@@ -1245,6 +1247,10 @@ def set_diffuser_pipe(pipe, new_pipe_type):
 
     fn = f'{sys._getframe(2).f_code.co_name}:{sys._getframe(1).f_code.co_name}' # pylint: disable=protected-access
     shared.log.debug(f"Pipeline class change: original={cls} target={new_pipe.__class__.__name__} device={pipe.device} fn={fn}") # pylint: disable=protected-access
+    
+    if shared.opts.diffusers_offload_mode == 'balanced':
+        new_pipe = apply_balanced_offload(new_pipe, force=True)
+    
     pipe = new_pipe
     return pipe
 


### PR DESCRIPTION
## Description

Some recent commit broke inpainting when called via API img2img. It would error out with the error:

```
10:03:53-571255 ERROR    Processing: step=base args={'prompt_embeds': 'cuda:0:torch.bfloat16:torch.Size([1, 154, 2048])', 'pooled_prompt_embeds': 'cuda:0:torch.bfloat16:torch.Size([1, 1280])',                                        'negative_prompt_embeds': 'cuda:0:torch.bfloat16:torch.Size([1, 154, 2048])', 'negative_pooled_prompt_embeds': 'cuda:0:torch.bfloat16:torch.Size([1, 1280])', 'guidance_scale': 6.0,                           'generator': [<torch._C.Generator object at 0x7018e1da7af0>], 'callback_on_step_end': <function diffusers_callback at 0x70192e095800>, 'callback_on_step_end_tensor_inputs':                                   ['latents', 'prompt_embeds', 'add_text_embeds', 'add_time_ids', 'noise_pred'], 'num_inference_steps': 47, 'eta': 1.0, 'guidance_rescale': 0.0, 'denoising_start': None,                                        'denoising_end': None, 'output_type': 'latent', 'image': [<PIL.Image.Image image mode=RGB size=896x1200 at 0x701917F64830>], 'strength': 0.82} Input type (CUDABFloat16Type) and                               weight type (CPUBFloat16Type) should be the same                                                                                                                                      10:03:53-574273 ERROR    Processing: RuntimeError
```

This PR fixes it and now img2img API calls works again.

## Environment and Testing

Running on Ubuntu 24 and on Nvidia RTX 3090
