### PR TITLE
Mark public re-exports

### DIFF
--- a/modules/images.py
+++ b/modules/images.py
@@ -12,10 +12,24 @@ import piexif
 import piexif.helper
 from PIL import Image, PngImagePlugin, ExifTags, ImageDraw
 from modules import sd_samplers, shared, script_callbacks, errors, paths
-from modules.images_grid import image_grid, get_grid_size, split_grid, combine_grid, check_grid_size, get_font, draw_grid_annotations, draw_prompt_matrix, GridAnnotation, Grid # pylint: disable=unused-import
-from modules.images_resize import resize_image # pylint: disable=unused-import
-from modules.images_namegen import FilenameGenerator, get_next_sequence_number # pylint: disable=unused-import
-from modules.video import save_video # pylint: disable=unused-import
+from modules.images_grid import (
+    image_grid as image_grid,
+    get_grid_size as get_grid_size,
+    split_grid as split_grid,
+    combine_grid as combine_grid,
+    check_grid_size as check_grid_size,
+    get_font as get_font,
+    draw_grid_annotations as draw_grid_annotations,
+    draw_prompt_matrix as draw_prompt_matrix,
+    GridAnnotation as GridAnnotation,
+    Grid as Grid,
+)
+from modules.images_resize import resize_image as resize_image
+from modules.images_namegen import (
+    FilenameGenerator as FilenameGenerator,
+    get_next_sequence_number as get_next_sequence_number,
+)
+from modules.video import save_video as save_video
 
 
 debug = errors.log.trace if os.environ.get('SD_PATH_DEBUG', None) is not None else lambda *args, **kwargs: None

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 import gradio as gr
 
 from installer import (
-    log,
+    log as log,
     print_dict,
     console as console,
     get_version as get_version,
@@ -21,11 +21,11 @@ log.debug("Initializing: shared module")
 import modules.memmon
 import modules.paths as paths
 from modules.json_helpers import (
-    readfile,
+    readfile as readfile,
     writefile as writefile,
 )
 from modules.shared_helpers import (
-    listdir,
+    listdir as listdir,
     walk_files as walk_files,
     html_path as html_path,
     html as html,

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -4,23 +4,53 @@ import os
 import sys
 import time
 import contextlib
-
 from enum import Enum
 from typing import TYPE_CHECKING
+
 import gradio as gr
-from installer import log, print_dict, console, get_version # pylint: disable=unused-import
-log.debug('Initializing: shared module')
+
+from installer import (
+    log,
+    print_dict,
+    console as console,
+    get_version as get_version,
+)
+
+log.debug("Initializing: shared module")
 
 import modules.memmon
 import modules.paths as paths
-from modules.json_helpers import readfile, writefile # pylint: disable=W0611
-from modules.shared_helpers import listdir, walk_files, html_path, html, req, total_tqdm # pylint: disable=W0611
+from modules.json_helpers import (
+    readfile,
+    writefile as writefile,
+)
+from modules.shared_helpers import (
+    listdir,
+    walk_files as walk_files,
+    html_path as html_path,
+    html as html,
+    req as req,
+    total_tqdm as total_tqdm,
+)
 from modules import errors, devices, shared_state, cmd_args, theme, history, files_cache
 from modules.shared_defaults import get_default_modes
-from modules.paths import models_path, script_path, data_path, sd_configs_path, sd_default_config, sd_model_file, default_sd_model_file, extensions_dir, extensions_builtin_dir # pylint: disable=W0611
-from modules.memstats import memory_stats, ram_stats # pylint: disable=unused-import
+from modules.paths import (
+    models_path as models_path,
+    script_path as script_path,
+    data_path as data_path,
+    sd_configs_path as sd_configs_path,
+    sd_default_config as sd_default_config,
+    sd_model_file as sd_model_file,
+    default_sd_model_file as default_sd_model_file,
+    extensions_dir as extensions_dir,
+    extensions_builtin_dir as extensions_builtin_dir,
+)
+from modules.memstats import (
+    memory_stats,
+    ram_stats as ram_stats,
+)
 
-log.debug('Initializing: pipelines')
+log.debug("Initializing: pipelines")
 from modules import shared_items
 from modules.interrogate.openclip import caption_models, caption_types, get_clip_models, refresh_clip_models
 from modules.interrogate.vqa import vlm_models, vlm_prompts, vlm_system, vlm_default

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -35,7 +35,7 @@ from modules.shared_helpers import (
 from modules import errors, devices, shared_state, cmd_args, theme, history, files_cache
 from modules.shared_defaults import get_default_modes
 from modules.paths import (
-    models_path as models_path,
+    models_path as models_path, # For compatibility, do not modify from here...
     script_path as script_path,
     data_path as data_path,
     sd_configs_path as sd_configs_path,
@@ -43,7 +43,7 @@ from modules.paths import (
     sd_model_file as sd_model_file,
     default_sd_model_file as default_sd_model_file,
     extensions_dir as extensions_dir,
-    extensions_builtin_dir as extensions_builtin_dir,
+    extensions_builtin_dir as extensions_builtin_dir, # ... to here.
 )
 from modules.memstats import (
     memory_stats,


### PR DESCRIPTION
Re-aliasing tells static type checkers that these are considered part of the public interface despite not being used.

See: https://typing.python.org/en/latest/spec/distributing.html#import-conventions