### PR TITLE
Linting rules: TCH -> TC

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -64,7 +64,7 @@ select = [
   "ISC",
   "ICN",
   "RSE",
-  "TCH",
+  "TC",
   "TID",
   "INT",
   "PLE",


### PR DESCRIPTION
~~The correct code is `TC`, not `TCH`.~~ Looks like it was `TCH` in the past, but it's now just `TC`.