### PR TITLE
Update PyRight Config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -386,7 +386,6 @@ exclude = [
 extraPaths = [
         "scripts",
         "pipelines",
-        "extensions-builtin",
         ]
 reportMissingImports = "none"
 reportInvalidTypeForm = "none"


### PR DESCRIPTION
- Add `scripts` and `pipelines` to `extraPaths` for module resolution.
  - `modules` doesn't need to be added because it already has a `__init__.py` file.
    - We can't simply slap in a `__init__.py` file to the `scripts` directory because it'll break every extension that incorrectly uses multiple files within the extension's own `scripts` directory and uses imports that include the `scripts` in the import path. This is ~~objectively~~ subjectively incorrect behavior by the extension authors, since extensions are supposed to always run in the context of the main program. A1111 WebUI not having a `scripts/__init__.py` file to begin with resulted in many extensions working that should have otherwise raised exceptions.
    - A1111 SD WebUI Tagcomplete is one of the more well-known extensions that has this issue. In the meantime, I'm going to submit a PR to them that fixes this issue.