### PR TITLE
Use `wslview` instead of `wsl-open` on WSL

### DIFF
--- a/modules/ui_common.py
+++ b/modules/ui_common.py
@@ -253,7 +253,7 @@ def open_folder(result_gallery, gallery_index = 0):
         if platform.system() == "Darwin":
             opener = "open"
         elif "microsoft-standard-WSL2" in platform.uname().release:
-            opener = "wslview"
+            opener = "wslview" if shutil.which("wslview") is not None else "wsl-open"
         else:
             opener = "xdg-open"
         subprocess.Popen([opener, path])  # pylint: disable=consider-using-with


### PR DESCRIPTION
`wslview` has been included by default in WSL images for a while now.

Also a very minor rewrite to split up the definition of the command and the actual `Popen` call.