### PR TITLE
Properly platform agnostic paths.

### DIFF
--- a/scripts/rocm/rocm_vars.py
+++ b/scripts/rocm/rocm_vars.py
@@ -1,15 +1,29 @@
+import os
+import sys
+import sysconfig
 from typing import Dict, Any, List, Tuple
+
+
+def _sitepackages_subpath(*parts: str) -> str:
+    """Return a {VIRTUAL_ENV}-prefixed path into site-packages using OS-native separators.
+
+    Works on both Windows (Lib/site-packages) and Linux (lib/pythonX.Y/site-packages).
+    """
+    site_pkgs = sysconfig.get_path('purelib')  # absolute path to site-packages inside the active venv
+    rel = os.path.relpath(site_pkgs, sys.prefix)  # platform-correct relative sub-path under venv root
+    return os.path.join("{VIRTUAL_ENV}", rel, *parts)
+
 
 GENERAL_VARS: Dict[str, Dict[str, Any]] = {
      "MIOPEN_SYSTEM_DB_PATH": {
-        "default": "{VIRTUAL_ENV}\\Lib\\site-packages\\_rocm_sdk_devel\\bin\\",
+        "default": _sitepackages_subpath("_rocm_sdk_devel", "bin") + os.sep,
         "desc": "MIOpen system DB path",
         "widget": "textbox",
         "options": None,
         "restart_required": True,
     },
     "ROCBLAS_TENSILE_LIBPATH": {
-        "default": "{VIRTUAL_ENV}\\Lib\\site-packages\\_rocm_sdk_devel\\bin\\rocblas\\library",
+        "default": _sitepackages_subpath("_rocm_sdk_devel", "bin", "rocblas", "library"),
         "desc": "rocBLAS Tensile library path",
         "widget": "textbox",
         "options": None,
@@ -86,7 +100,7 @@ GENERAL_VARS: Dict[str, Dict[str, Any]] = {
         "restart_required": False,
     },
     "PYTORCH_TUNABLEOP_CACHE_DIR": {
-        "default": "{ROOT}\\models\\tunable",
+        "default": os.path.join("{ROOT}", "models", "tunable"),
         "desc": "TunableOp cache directory",
         "widget": "textbox",
         "options": None,

--- a/scripts/rocm_ext.py
+++ b/scripts/rocm_ext.py
@@ -7,7 +7,7 @@ from modules import scripts_manager, shared
 
 class ROCmScript(scripts_manager.Script):
     def title(self):
-        return "Windows ROCm: Advanced Config"
+        return "ROCm: Advanced Config"
 
     def show(self, _is_img2img):
         if shared.cmd_opts.use_rocm or installer.torch_info.get('type') == 'rocm':
@@ -35,7 +35,7 @@ class ROCmScript(scripts_manager.Script):
                 choices = rocm_mgr._dropdown_choices(meta["options"])
                 display = rocm_mgr._dropdown_display(val, meta["options"])
                 return gr.Dropdown(label=meta["desc"], choices=choices, value=display, elem_id=f"rocm_var_{name.lower()}")
-            return gr.Textbox(label=meta["desc"], value=rocm_mgr._expand_venv(val), lines=1)
+            return gr.Textbox(label=meta["desc"], value=rocm_mgr._expand_venv(val), lines=2)
 
         def _info_html():
             d = rocm_mgr.info()


### PR DESCRIPTION
System DB, rocBLAS tensile library and tunabeops cache folder now properly check linux python vEnv paths. 