### PR TITLE
Fix ROCm Tensile library paths for Linux natively

### DIFF
--- a/scripts/rocm/rocm_vars.py
+++ b/scripts/rocm/rocm_vars.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import sysconfig
+import platform
 from typing import Dict, Any, List, Tuple
 
 
@@ -18,15 +19,15 @@ def _sitepackages_subpath(*parts: str) -> str:
 
 
 GENERAL_VARS: Dict[str, Dict[str, Any]] = {
-     "MIOPEN_SYSTEM_DB_PATH": {
-        "default": _sitepackages_subpath("{LIBS_PKG}", _BIN_DIR) + os.sep,
+    "MIOPEN_SYSTEM_DB_PATH": {
+        "default": _sitepackages_subpath("{LIBS_PKG}", _BIN_DIR) + os.sep if platform.system() == "Windows" else "",
         "desc": "MIOpen system path",
         "widget": "textbox",
         "options": None,
         "restart_required": True,
     },
     "ROCBLAS_TENSILE_LIBPATH": {
-        "default": _sitepackages_subpath("{LIBS_PKG}", _BIN_DIR, "rocblas", "library"),
+        "default": _sitepackages_subpath("{LIBS_PKG}", _BIN_DIR, "rocblas", "library") if platform.system() == "Windows" else "",
         "desc": "rocBLAS Tensile library path",
         "widget": "textbox",
         "options": None,


### PR DESCRIPTION
The recent path fixes for ROCm assume a Windows directory structure (_rocm_sdk_devel/bin/rocblas/library or //bin/...). On Linux, PyTorch natively extracts these libraries to a different structure (torch/lib/rocblas/library/TensileLibrary_lazy_gfxXXXX.dat) and handles the linking internally via RUNPATH.

Forcing the ROCBLAS_TENSILE_LIBPATH environment variable on Linux overwrites PyTorch's native paths with a malformed directory, causing rocBLAS to fail its directory iterator and crash with a Cannot read TensileLibrary.dat fallback error.

The Fix:
I added a platform.system() == "Windows" check to the default variables. This preserves the manual environment override for Windows users who need it, but passes an empty string for Linux users, allowing the native PyTorch wheels to locate their own libraries successfully.
