### PR TITLE
fix sd_checkpoint.list_models leaving stale sd_models.checkpoints_list

### DIFF
--- a/modules/sd_checkpoint.py
+++ b/modules/sd_checkpoint.py
@@ -157,7 +157,9 @@ def list_models():
         elif shared.cmd_opts.ckpt != shared.default_sd_model_file:
             log.warning(f'Load model: path="{shared.cmd_opts.ckpt}" not found')
     log.info(f'Available Models: safetensors="{shared.opts.ckpt_dir}":{len(safetensors_list)} diffusers="{shared.opts.diffusers_dir}":{len(diffusers_list)} reference={len(list(shared.reference_models))} items={len(checkpoints_list)} time={time.time()-t0:.2f}')
-    checkpoints_list = dict(sorted(checkpoints_list.items(), key=lambda cp: cp[1].filename))
+    sorted_items = sorted(checkpoints_list.items(), key=lambda cp: cp[1].filename)
+    checkpoints_list.clear()
+    checkpoints_list.update(sorted_items)
 
 
 def update_model_hashes(model_list: dict | None = None, model_type: str = 'checkpoint'):


### PR DESCRIPTION
## Description

Fixes the newly downloaded models not showing up in most consumers of the list even when manually refreshing.

## Notes

list_models() ended with `checkpoints_list = dict(sorted(...))`, which rebound the module-level name to a fresh dict object. sd_models.py line 18 does `from modules.sd_checkpoint import ... checkpoints_list`, capturing a reference to the original dict at import time. Every subsequent list_models() call cleared and refilled the sd_checkpoint binding but left the sd_models binding frozen at the state it had after the first call. ui_extra_networks_checkpoints, ui_models, extras, xyz_grid_classes, and sd-extension-system-info all read through sd_models.checkpoints_list, so none of them could see models added after startup without a full restart.

Sort in place instead, preserving dict identity so every importer stays in sync with sd_checkpoint.checkpoints_list.