### PR TITLE
Fix invalid ts2utc behavior

### DIFF
--- a/modules/extensions.py
+++ b/modules/extensions.py
@@ -35,10 +35,8 @@ def format_dt(d: datetime, seconds = False) -> str:
 
 
 def ts2utc(timestamp: int) -> datetime:
-    try:
-        return datetime.fromtimestamp(timestamp, timezone.utc)
-    except Exception:
-        return "unknown"
+    return datetime.fromtimestamp(timestamp, timezone.utc)
+
 
 def active() -> list[Extension]:
     if shared.opts.disable_all_extensions == "all":


### PR DESCRIPTION
Not sure why this was changed, but trying to hide the exception and return "unknown" just makes things worse.

1. An exception is *supposed* to be raised when getting bad data because it means either the data source changed how it's formatted or there's a bug elsewhere that needs to be fixed.
2. "unknown" is not a datetime, and anything calling this function expecting a `datetime` to be returned will raise a TypeError.
3. This prevents the traceback from pointing to where the *actual* error occurred.

Additionally, we don't want to return a default value if it can't be parsed because that just sweeps the issue under the rug and hides the fact that something is going wrong.