### PR TITLE
Typing, import, and UI file setup updates

### DIFF
--- a/modules/civitai/metadata_civitai.py
+++ b/modules/civitai/metadata_civitai.py
@@ -216,7 +216,7 @@ def civit_search_metadata(title: str | None = None, raw: bool = False):
             scanned += 1
             candidates.append(item)
     log.debug(f'CivitAI search metadata: type={title if isinstance(title, str) else "all"} workers={max_workers} skip={len(re_skip)} items={len(candidates)}')
-    import concurrent
+    import concurrent.futures
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         future_items = {}
         for candidate in candidates:

--- a/modules/lora/lora_load.py
+++ b/modules/lora/lora_load.py
@@ -1,6 +1,6 @@
 import os
 import time
-import concurrent
+import concurrent.futures
 from modules import shared, errors, sd_models, sd_models_compile, files_cache
 from modules.logger import log
 from modules.lora import network, lora_overrides, lora_convert, lora_diffusers

--- a/modules/sdnq/file_loader.py
+++ b/modules/sdnq/file_loader.py
@@ -3,7 +3,7 @@ import concurrent.futures
 import torch
 
 
-def map_keys(key: str, key_mapping: dict) -> str:
+def map_keys(key: str, key_mapping: dict | None) -> str:
     new_key = key
     if key_mapping:
         for pattern, replacement in key_mapping.items():
@@ -13,7 +13,7 @@ def map_keys(key: str, key_mapping: dict) -> str:
     return new_key
 
 
-def load_safetensors(files: list[str], state_dict: dict | None = None, key_mapping: dict | None = None, device: torch.device = "cpu") -> dict:
+def load_safetensors(files: list[str], state_dict: dict | None = None, key_mapping: dict | None = None, device: torch.device = "cpu") -> None:
     from safetensors.torch import safe_open
     if state_dict is None:
         state_dict = {}
@@ -23,7 +23,7 @@ def load_safetensors(files: list[str], state_dict: dict | None = None, key_mappi
                 state_dict[map_keys(key, key_mapping)] = f.get_tensor(key)
 
 
-def load_threaded(files: list[str], state_dict: dict | None = None, key_mapping: dict | None = None, device: torch.device = "cpu") -> dict:
+def load_threaded(files: list[str], state_dict: dict | None = None, key_mapping: dict | None = None, device: torch.device = "cpu") -> None:
     future_items = {}
     if state_dict is None:
         state_dict = {}
@@ -34,7 +34,7 @@ def load_threaded(files: list[str], state_dict: dict | None = None, key_mapping:
             future.result()
 
 
-def load_streamer(files: list[str], state_dict: dict | None = None, key_mapping: dict | None = None, device: torch.device = "cpu") -> dict:
+def load_streamer(files: list[str], state_dict: dict | None = None, key_mapping: dict | None = None, device: torch.device = "cpu") -> None:
     # requires pip install runai_model_streamer
     from runai_model_streamer import SafetensorsStreamer
     if state_dict is None:

--- a/modules/styles.py
+++ b/modules/styles.py
@@ -336,7 +336,7 @@ class StyleDatabase:
         self.styles.clear()
 
         def list_folder(folder):
-            import concurrent
+            import concurrent.futures
             future_items = {}
             style_files = list(files_cache.list_files(folder, ext_filter=['.json'], recursive=files_cache.not_hidden))
             with concurrent.futures.ThreadPoolExecutor(max_workers=shared.max_workers) as executor:

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -764,7 +764,7 @@ def create_ui(container, button_parent: gr.Button, tabname: str, skip_indexing =
             global refresh_time # pylint: disable=global-statement
             refresh_time = time.time()
         if not skip_indexing:
-            import concurrent
+            import concurrent.futures
             with concurrent.futures.ThreadPoolExecutor(max_workers=shared.max_workers) as executor:
                 for page in get_pages():
                     executor.submit(page.create_items, ui.tabname)

--- a/modules/ui_extra_networks_checkpoints.py
+++ b/modules/ui_extra_networks_checkpoints.py
@@ -1,7 +1,7 @@
 import os
 import html
 import json
-import concurrent
+import concurrent.futures
 from datetime import datetime
 from modules import shared, ui_extra_networks, sd_models, modelstats, paths, devices
 from modules.logger import log

--- a/modules/ui_extra_networks_lora.py
+++ b/modules/ui_extra_networks_lora.py
@@ -1,6 +1,6 @@
 import os
 import json
-import concurrent
+import concurrent.futures
 from modules import shared, ui_extra_networks, modelstats
 from modules.logger import log
 from modules.lora import lora_load

--- a/modules/ui_javascript.py
+++ b/modules/ui_javascript.py
@@ -1,9 +1,10 @@
 import os
+
 import gradio.routes
-import gradio.utils
+
 from modules import extensions, scripts_manager, shared, theme
-from modules.paths import script_path, data_path
 from modules.logger import log
+from modules.paths import data_path, script_path
 
 
 def webpath(fn):

--- a/modules/ui_javascript.py
+++ b/modules/ui_javascript.py
@@ -12,7 +12,7 @@ def webpath(fn):
     else:
         uri = fn
     uri = uri.replace('\\', '/')
-    uri = f'file={uri}?{os.path.getmtime(fn)}'
+    uri = f'file={uri}?{int(os.path.getmtime(fn))}'
     return uri
 
 

--- a/modules/ui_javascript.py
+++ b/modules/ui_javascript.py
@@ -1,9 +1,8 @@
 import os
 import gradio.routes
 import gradio.utils
-from modules import shared, theme
+from modules import extensions, scripts_manager, shared, theme
 from modules.paths import script_path, data_path
-import modules.scripts_manager
 from modules.logger import log
 
 
@@ -14,7 +13,6 @@ def webpath(fn):
         uri = fn
     uri = uri.replace('\\', '/')
     uri = f'file={uri}?{os.path.getmtime(fn)}'
-    # uri = f'js?file={uri}&{os.path.getmtime(fn)}'
     return uri
 
 
@@ -29,7 +27,7 @@ def html_head():
         else:
             head += f'<script type="text/javascript" src="{webpath(script_js)}"></script>\n'
     added = []
-    for script in modules.scripts_manager.list_scripts("javascript", ".js"):
+    for script in scripts_manager.list_scripts("javascript", ".js"):
         if script.filename in main or script.filename in skip:
             continue
         if '.esm' in script.filename or '.mjs' in script.filename:
@@ -37,7 +35,7 @@ def html_head():
         else:
             head += f'<script type="text/javascript" src="{webpath(script.path)}"></script>\n'
         added.append(script.path)
-    for script in modules.scripts_manager.list_scripts("javascript", ".mjs"):
+    for script in scripts_manager.list_scripts("javascript", ".mjs"):
         head += f'<script type="module" src="{webpath(script.path)}"></script>\n'
         added.append(script.path)
     added = [a.replace(script_path, '').replace('\\', '/') for a in added]
@@ -71,22 +69,22 @@ def html_css(css: list[str]):
         f = os.path.join(script_path, 'javascript', cssfile)
         if os.path.isfile(f):
             head += stylesheet(f)
-    for cssfile in modules.scripts_manager.list_files_with_name("style.css"):
+    for cssfile in scripts_manager.list_files_with_name("style.css"):
         if not os.path.isfile(cssfile):
             continue
         head += stylesheet(cssfile)
 
     usercss = os.path.join(data_path, "user.css") if os.path.exists(os.path.join(data_path, "user.css")) else None
-    if modules.shared.opts.theme_type == 'Standard':
-        themecss = os.path.join(script_path, "javascript", f"{modules.shared.opts.gradio_theme}.css")
+    if shared.opts.theme_type == 'Standard':
+        themecss = os.path.join(script_path, "javascript", f"{shared.opts.gradio_theme}.css")
         if os.path.exists(themecss):
             head += stylesheet(themecss)
             log.debug(f'UI theme: css="{themecss}" base="{css}" user="{usercss}"')
         else:
             log.error(f'UI theme: css="{themecss}" path="{os.getcwd()}" not found')
-    elif modules.shared.opts.theme_type == 'Modern':
-        theme_folder = next((e.path for e in modules.extensions.extensions if e.name == 'sdnext-modernui'), None)
-        themecss = os.path.join(theme_folder or '', 'themes', f'{modules.shared.opts.gradio_theme}.css')
+    elif shared.opts.theme_type == 'Modern':
+        theme_folder = next((e.path for e in extensions.extensions if e.name == 'sdnext-modernui'), None)
+        themecss = os.path.join(theme_folder or '', 'themes', f'{shared.opts.gradio_theme}.css')
         if os.path.exists(themecss):
             head += stylesheet(themecss)
             log.debug(f'UI theme: css="{themecss}" base="{css}" user="{usercss}"')

--- a/modules/ui_javascript.py
+++ b/modules/ui_javascript.py
@@ -67,11 +67,10 @@ def html_css(css: list[str]):
         return f'<link rel="stylesheet" property="stylesheet" href="{webpath(fn)}">'
 
     head = ''
-    if css is not None:
-        for cssfile in css:
-            f = os.path.join(script_path, 'javascript', cssfile)
-            if os.path.isfile(f):
-                head += stylesheet(f)
+    for cssfile in css:
+        f = os.path.join(script_path, 'javascript', cssfile)
+        if os.path.isfile(f):
+            head += stylesheet(f)
     for cssfile in modules.scripts_manager.list_files_with_name("style.css"):
         if not os.path.isfile(cssfile):
             continue
@@ -104,9 +103,12 @@ def reload_javascript():
     login = html_login()
     js = html_head()
 
-    css_base = theme.reload_gradio_theme()
-    css_timesheet = "timesheet.css"
-    css = html_css([css_base, css_timesheet])
+    css_files: list[str] = []
+    if (css_base := theme.reload_gradio_theme()) is not None:
+        css_files.append(css_base)
+    css_files.append("timesheet.css")
+
+    css = html_css(css_files)
     body = html_body()
 
     def template_response(*args, **kwargs):


### PR DESCRIPTION
- Correct typing in `file_loader.py`
- Update `concurrent` imports to `concurrent.futures`
  - Python 3.14 adds `concurrent.interpreters` which isn't needed.
- Slight improvement to browser error readability in console.
  - Shorten the cache busting section of the file URL since sub-second precision really isn't needed.
- Cleanup `ui_javascript.py`
  - Remove unused import and old commented-out line.
  - Omit sending `None` to `html_css`
    - (Yes, it uses an assignment expression, but they're designed for small one-off uses like this).
  - Update modules imports + accessing, and organize imports.