### PR TITLE
Feat/anima custom transformer and lora

### DIFF
--- a/modules/lora/lora_convert.py
+++ b/modules/lora/lora_convert.py
@@ -502,4 +502,9 @@ def assign_network_names_to_compvis_modules(sd_model):
             if "norm" in network_name and "linear" not in network_name and shared.sd_model_type != "sd3":
                 continue
             module.network_layer_name = network_name
+    if hasattr(sd_model, 'llm_adapter') and sd_model.llm_adapter is not None:
+        for name, module in sd_model.llm_adapter.named_modules():
+            network_name = "lora_llm_adapter_" + name.replace(".", "_")
+            network_layer_mapping[network_name] = module
+            module.network_layer_name = network_name
     shared.sd_model.network_layer_mapping = network_layer_mapping

--- a/modules/lora/lora_load.py
+++ b/modules/lora/lora_load.py
@@ -64,6 +64,13 @@ def load_safetensors(name, network_on_disk: network.NetworkOnDisk) -> network.Ne
         if zimage_net is not None:
             lora_cache[name] = zimage_net
         return zimage_net
+    if shared.sd_model_type == 'anima':
+        from pipelines.anima import anima_lora
+        lora_scale = shared.opts.extra_networks_default_multiplier
+        anima_net = anima_lora.try_load_lora(name, network_on_disk, lora_scale)
+        if anima_net is not None:
+            lora_cache[name] = anima_net
+        return anima_net
     net = network.Network(name, network_on_disk)
     net.mtime = os.path.getmtime(network_on_disk.filename)
     state_dict = sd_models.read_state_dict(network_on_disk.filename, what='network')

--- a/modules/lora/lora_overrides.py
+++ b/modules/lora/lora_overrides.py
@@ -28,6 +28,7 @@ allow_native = [
     'f1',
     'chroma',
     'zimage',
+    'anima',
 ]
 
 

--- a/modules/lora/network.py
+++ b/modules/lora/network.py
@@ -68,6 +68,8 @@ class NetworkOnDisk:
             return 'chroma'
         if base.startswith('zimage'):
             return 'zimage'
+        if base.startswith('anima'):
+            return 'anima'
         if base.startswith('qwen'):
             return 'qwen'
 
@@ -98,6 +100,8 @@ class NetworkOnDisk:
             return 'xl'
         if 'chroma' in self.name.lower():
             return 'chroma'
+        if 'anima' in self.name.lower():
+            return 'anima'
 
         return ''
 

--- a/modules/lora/networks.py
+++ b/modules/lora/networks.py
@@ -9,7 +9,7 @@ from modules.logger import log, console
 
 
 applied_layers: list[str] = []
-default_components = ['text_encoder', 'text_encoder_2', 'text_encoder_3', 'text_encoder_4', 'unet', 'transformer', 'transformer_2']
+default_components = ['text_encoder', 'text_encoder_2', 'text_encoder_3', 'text_encoder_4', 'unet', 'transformer', 'transformer_2', 'llm_adapter']
 
 
 def network_activate(include=None, exclude=None):
@@ -99,7 +99,7 @@ def network_deactivate(include=None, exclude=None):
             sd_models.move_model(sd_model, device=devices.cpu)
         modules = {}
 
-        components = include if len(include) > 0 else ['text_encoder', 'text_encoder_2', 'text_encoder_3', 'unet', 'transformer']
+        components = include if len(include) > 0 else ['text_encoder', 'text_encoder_2', 'text_encoder_3', 'unet', 'transformer', 'llm_adapter']
         components = [x for x in components if x not in exclude]
         active_components = []
         for name in components:

--- a/modules/modeldata.py
+++ b/modules/modeldata.py
@@ -72,7 +72,9 @@ def get_model_type(pipe):
         model_type = 'sana'
     elif "HiDream" in name:
         model_type = 'h1'
-    elif "Cosmos2TextToImage" in name or "AnimaTextToImage" in name:
+    elif "AnimaTextToImage" in name:
+        model_type = 'anima'
+    elif "Cosmos2TextToImage" in name:
         model_type = 'cosmos'
     elif "FLite" in name:
         model_type = 'flite'

--- a/modules/sd_samplers_common.py
+++ b/modules/sd_samplers_common.py
@@ -11,7 +11,7 @@ from modules.image import convert
 
 SamplerData = namedtuple('SamplerData', ['name', 'constructor', 'aliases', 'options'])
 approximation_indexes = { "Simple": 0, "Approximate": 1, "TAESD": 2, "Full VAE": 3 }
-flow_models = ['f1', 'f2', 'sd3', 'lumina', 'auraflow', 'sana', 'zimage', 'lumina2', 'cogview4', 'h1', 'cosmos', 'chroma', 'omnigen', 'omnigen2', 'longcat']
+flow_models = ['f1', 'f2', 'sd3', 'lumina', 'auraflow', 'sana', 'zimage', 'lumina2', 'cogview4', 'h1', 'cosmos', 'anima', 'chroma', 'omnigen', 'omnigen2', 'longcat']
 warned = False
 queue_lock = threading.Lock()
 

--- a/modules/sd_unet.py
+++ b/modules/sd_unet.py
@@ -9,7 +9,7 @@ failed_unet = []
 debug = os.environ.get('SD_LOAD_DEBUG', None) is not None
 
 
-dit_models = ['Flux', 'StableDiffusion3', 'HiDream', 'Lumina2', 'Chroma', 'Wan', 'Qwen']
+dit_models = ['Flux', 'StableDiffusion3', 'HiDream', 'Lumina2', 'Chroma', 'Wan', 'Qwen', 'Anima']
 
 
 def load_unet_sdxl_nunchaku(repo_id):

--- a/modules/vae/sd_vae_taesd.py
+++ b/modules/vae/sd_vae_taesd.py
@@ -45,7 +45,7 @@ prev_cls = ''
 prev_type = ''
 prev_model = ''
 lock = threading.Lock()
-supported = ['sd', 'sdxl', 'sd3', 'f1', 'f2', 'h1', 'zimage', 'lumina2', 'hunyuanvideo', 'wanai', 'chrono', 'cosmos', 'mochivideo', 'pixartsigma', 'pixartalpha', 'hunyuandit', 'omnigen', 'qwen', 'longcat', 'omnigen2', 'flite', 'ovis', 'kandinsky5', 'glmimage', 'cogview3', 'cogview4']
+supported = ['sd', 'sdxl', 'sd3', 'f1', 'f2', 'h1', 'zimage', 'lumina2', 'hunyuanvideo', 'wanai', 'chrono', 'cosmos', 'anima', 'mochivideo', 'pixartsigma', 'pixartalpha', 'hunyuandit', 'omnigen', 'qwen', 'longcat', 'omnigen2', 'flite', 'ovis', 'kandinsky5', 'glmimage', 'cogview3', 'cogview4']
 
 
 def warn_once(msg, variant=None):
@@ -74,7 +74,7 @@ def get_model(model_type = 'decoder', variant = None):
         variant = 'TAE FLUX.2'
     elif model_cls in {'sd3'}:
         variant = 'TAE SD3'
-    elif model_cls in {'wanai', 'qwen', 'chrono', 'cosmos', 'fibo'}:
+    elif model_cls in {'wanai', 'qwen', 'chrono', 'cosmos', 'anima', 'fibo'}:
         variant = variant or 'TAE WanVideo'
     elif model_cls not in supported:
         warn_once(f'cls={shared.sd_model.__class__.__name__} type={shared.sd_model_type} unsuppported', variant=variant)

--- a/pipelines/anima/anima_lora.py
+++ b/pipelines/anima/anima_lora.py
@@ -1,0 +1,234 @@
+"""Anima native LoRA loader.
+
+Handles three trainer formats observed in community Anima LoRAs:
+- Kohya: lora_unet_blocks_0_self_attn_q_proj.lora_down.weight (+ .alpha)
+- BFL/AI-toolkit: diffusion_model.blocks.0.self_attn.q_proj.lora_A.weight
+- Hybrid: BFL key shape with .alpha scalars, optionally with a Qwen3 text
+  encoder branch under text_encoders.qwen3_06b.transformer.model.layers...
+
+Routes paths to one of three live components (transformer, llm_adapter,
+text_encoder) via lora_convert.assign_network_names_to_compvis_modules and
+the resulting network_layer_mapping.
+
+Path renames mirror the Cosmos 2.0 table from
+diffusers.loaders.single_file_utils.convert_cosmos_transformer_checkpoint_to_diffusers,
+transposed into flat (underscore) form so the rewritten path matches
+network_layer_mapping keys without further conversion.
+"""
+
+import os
+import time
+from collections import OrderedDict
+from modules import shared, sd_models
+from modules.logger import log
+from modules.lora import network, network_lora, lora_convert
+from modules.lora import lora_common as l
+
+
+KOHYA_PREFIX = 'lora_unet_'
+BFL_ADAPTER_PREFIX = 'diffusion_model.llm_adapter.'
+BFL_TRANSFORMER_PREFIX = 'diffusion_model.'
+BFL_TE_PREFIX = 'text_encoders.qwen3_06b.transformer.model.'
+
+LORA_MARKERS = ('.lora_down.', '.lora_up.', '.lora_A.', '.lora_B.')
+
+# Cosmos 2.0 path rename, applied to underscore-flattened paths. Order
+# mirrors diffusers TRANSFORMER_KEYS_RENAME_DICT_COSMOS_2_0: longer
+# substrings precede substrings nested inside them, so str.replace does
+# not consume a fragment that a later rule still needs to match.
+COSMOS_2_FLAT_RENAME = OrderedDict([
+    ('t_embedder_1', 'time_embed_t_embedder'),
+    ('t_embedding_norm', 'time_embed_norm'),
+    ('blocks', 'transformer_blocks'),
+    ('adaln_modulation_self_attn_1', 'norm1_linear_1'),
+    ('adaln_modulation_self_attn_2', 'norm1_linear_2'),
+    ('adaln_modulation_cross_attn_1', 'norm2_linear_1'),
+    ('adaln_modulation_cross_attn_2', 'norm2_linear_2'),
+    ('adaln_modulation_mlp_1', 'norm3_linear_1'),
+    ('adaln_modulation_mlp_2', 'norm3_linear_2'),
+    ('self_attn', 'attn1'),
+    ('cross_attn', 'attn2'),
+    ('q_proj', 'to_q'),
+    ('k_proj', 'to_k'),
+    ('v_proj', 'to_v'),
+    ('output_proj', 'to_out_0'),
+    ('q_norm', 'norm_q'),
+    ('k_norm', 'norm_k'),
+    ('mlp_layer1', 'ff_net_0_proj'),
+    ('mlp_layer2', 'ff_net_2'),
+    ('x_embedder_proj_1', 'patch_embed_proj'),
+    ('final_layer_adaln_modulation_1', 'norm_out_linear_1'),
+    ('final_layer_adaln_modulation_2', 'norm_out_linear_2'),
+    ('final_layer_linear', 'proj_out'),
+])
+
+
+def try_load_lora(name, network_on_disk, lora_scale):
+    """Try loading an Anima LoRA as native modules.
+
+    Returns a Network with native modules, or None if the file is not a
+    recognized Anima format. Recognition is gated on Anima-specific path
+    fragments so a non-Anima file routed here under a mounted Anima model
+    is rejected rather than force-loaded.
+    """
+    t0 = time.time()
+    state_dict = sd_models.read_state_dict(network_on_disk.filename, what='network')
+    has_lora = any(any(m in k for m in LORA_MARKERS) for k in state_dict)
+    if not has_lora:
+        return None
+    is_anima = any(
+        k.startswith(KOHYA_PREFIX + 'blocks_')
+        or k.startswith(BFL_TRANSFORMER_PREFIX + 'blocks.')
+        or k.startswith(BFL_ADAPTER_PREFIX)
+        or k.startswith(BFL_TE_PREFIX)
+        for k in state_dict
+    )
+    if not is_anima:
+        return None
+    state_dict = apply_lora_alphas(state_dict)
+    sd_model = getattr(shared.sd_model, 'pipe', shared.sd_model)
+    lora_convert.assign_network_names_to_compvis_modules(sd_model)
+    net = network.Network(name, network_on_disk)
+    net.mtime = os.path.getmtime(network_on_disk.filename)
+    matched = 0
+    unmatched = 0
+    unmatched_samples = []
+    for base, weights in group_keys(state_dict):
+        network_key = resolve_network_key(base)
+        if network_key is None:
+            unmatched += 1
+            if len(unmatched_samples) < 5:
+                unmatched_samples.append(base)
+            continue
+        sd_module = sd_model.network_layer_mapping.get(network_key)
+        if sd_module is None:
+            unmatched += 1
+            if len(unmatched_samples) < 5:
+                unmatched_samples.append(f'{base} (key={network_key})')
+            continue
+        if not shapes_match(sd_module, weights):
+            log.warning(f'Network load: type=LoRA name="{name}" shape mismatch key={network_key}')
+            continue
+        nw = network.NetworkWeights(network_key=network_key, sd_key=network_key, w=weights, sd_module=sd_module)
+        net.modules[network_key] = network_lora.NetworkModuleLora(net, nw)
+        matched += 1
+    if matched == 0:
+        return None
+    log.debug(f'Network load: type=LoRA name="{name}" native modules={matched} unmatched={unmatched} scale={lora_scale}')
+    if unmatched > 0 and l.debug:
+        log.debug(f'Network load: type=LoRA name="{name}" unmatched_samples={unmatched_samples}')
+    l.timer.activate += time.time() - t0
+    return net
+
+
+def apply_lora_alphas(state_dict):
+    """Bake .alpha scalars into lora_down / lora_up.
+
+    Native module loading consumes lora_down/lora_up directly; there is no
+    alpha kwarg path. Mirrors flux2_lora.apply_lora_alphas, with kohya and
+    BFL down/up names both supported (the hybrid format uses BFL keys with
+    kohya-style .alpha).
+    """
+    alpha_keys = [k for k in state_dict if k.endswith('.alpha')]
+    if not alpha_keys:
+        return state_dict
+    for alpha_key in alpha_keys:
+        base = alpha_key[:-len('.alpha')]
+        down_key = next((c for c in (f'{base}.lora_down.weight', f'{base}.lora_A.weight') if c in state_dict), None)
+        if down_key is None:
+            continue
+        rank = state_dict[down_key].shape[0]
+        alpha = state_dict.pop(alpha_key).item()
+        scale = alpha / rank
+        scale_down = scale
+        scale_up = 1.0
+        while scale_down * 2 < scale_up:
+            scale_down *= 2
+            scale_up /= 2
+        state_dict[down_key] = state_dict[down_key] * scale_down
+        up_key = next((c for c in (f'{base}.lora_up.weight', f'{base}.lora_B.weight') if c in state_dict), None)
+        if up_key is not None:
+            state_dict[up_key] = state_dict[up_key] * scale_up
+    remaining = [k for k in state_dict if k.endswith('.alpha')]
+    if remaining:
+        log.debug(f'Network load: type=LoRA stripped {len(remaining)} orphaned alpha keys')
+        for k in remaining:
+            del state_dict[k]
+    return state_dict
+
+
+def normalize_weight_key(suffix):
+    """Rewrite PEFT-style suffixes to kohya/native form (lora_A to lora_down, lora_B to lora_up)."""
+    return suffix.replace('lora_A.', 'lora_down.').replace('lora_B.', 'lora_up.')
+
+
+def group_keys(state_dict):
+    """Group state-dict keys by base path and yield (base, weights) pairs.
+
+    Bases keep their source key shape (kohya flat or BFL dotted) for
+    component routing in resolve_network_key.
+    """
+    groups = {}
+    for key, weight in state_dict.items():
+        base = None
+        suffix = None
+        if key.startswith(KOHYA_PREFIX):
+            base, _, suffix = key.partition('.')
+        else:
+            for marker in LORA_MARKERS:
+                pos = key.find(marker)
+                if pos != -1:
+                    base = key[:pos]
+                    suffix = key[pos + 1:]
+                    break
+        if base is None or suffix is None:
+            continue
+        groups.setdefault(base, {})[normalize_weight_key(suffix)] = weight
+    for base, weights in groups.items():
+        if 'lora_down.weight' in weights and 'lora_up.weight' in weights:
+            yield base, weights
+
+
+def resolve_network_key(base):
+    """Map a grouped base path to the network_layer_mapping lookup key.
+
+    Adapter and TE prefixes must be checked before the bare BFL transformer
+    prefix because both are extensions of diffusion_model.
+    """
+    if base.startswith(KOHYA_PREFIX):
+        flat = base[len(KOHYA_PREFIX):]
+        return 'lora_transformer_' + cosmos_rename_flat(flat)
+    if base.startswith(BFL_ADAPTER_PREFIX):
+        rest = base[len(BFL_ADAPTER_PREFIX):]
+        return 'lora_llm_adapter_' + rest.replace('.', '_')
+    if base.startswith(BFL_TE_PREFIX):
+        rest = base[len(BFL_TE_PREFIX):]
+        return 'lora_te_' + rest.replace('.', '_')
+    if base.startswith(BFL_TRANSFORMER_PREFIX):
+        rest = base[len(BFL_TRANSFORMER_PREFIX):]
+        flat = rest.replace('.', '_')
+        return 'lora_transformer_' + cosmos_rename_flat(flat)
+    return None
+
+
+def cosmos_rename_flat(flat):
+    """Apply the Cosmos 2.0 path rename to a flattened path."""
+    for k, v in COSMOS_2_FLAT_RENAME.items():
+        flat = flat.replace(k, v)
+    return flat
+
+
+def shapes_match(sd_module, weights):
+    """Confirm LoRA rank dimensions line up with the live module weight."""
+    if not hasattr(sd_module, 'weight'):
+        return True
+    if hasattr(sd_module, 'sdnq_dequantizer'):
+        mod_shape = sd_module.sdnq_dequantizer.original_shape
+    else:
+        mod_shape = sd_module.weight.shape
+    if len(mod_shape) < 2:
+        return False
+    return (
+        weights['lora_down.weight'].shape[1] == mod_shape[1]
+        and weights['lora_up.weight'].shape[0] == mod_shape[0]
+    )

--- a/pipelines/anima/anima_transformer.py
+++ b/pipelines/anima/anima_transformer.py
@@ -1,0 +1,216 @@
+"""Anima custom-transformer loader.
+
+Called from :func:`pipelines.model_anima.load_anima` when the user has selected
+a transformer file via the UNET dropdown (``shared.opts.sd_unet``). Reads the
+safetensors directly, strips the BFL-style prefix, splits off the bundled
+``llm_adapter.*`` keys, and routes the two halves into the diffusers
+``CosmosTransformer3DModel`` and the remote ``AnimaLLMAdapter`` respectively.
+
+The transformer half is run through diffusers'
+``convert_cosmos_transformer_checkpoint_to_diffusers`` (Cosmos 2.0 branch),
+whose rename table covers Anima's native key fragments exactly, so the
+converted state dict drops cleanly into ``CosmosTransformer3DModel`` with no
+ad-hoc renames needed here. The adapter half matches the base repo's
+``llm_adapter/diffusion_pytorch_model.safetensors`` exactly, so it loads
+as-is.
+
+Supported input formats (safetensors only; GGUF and .pth are rejected early):
+
+- Bare BFL keys: ``blocks.0.self_attn.q_proj.weight`` (e.g. ``rdbtAnima_v027``)
+- ``model.diffusion_model.`` prefix (e.g. ``animaika_v35``)
+- ``diffusion_model.`` prefix (ComfyUI-style export)
+
+Quantization: SDNQ (pre/post/auto) and ``layerwise_quantization`` are honored.
+SDNQ pre-mode is applied post-load here because this path bypasses
+``from_pretrained``, where ``quantization_config`` normally takes effect.
+TensorRT (``NVIDIAModelOptConfig``) is not supported and is skipped with a
+warning. GGUF would require a separate converter and is not supported.
+"""
+
+import os
+import time
+import diffusers
+import huggingface_hub as hf
+from modules import shared, devices, sd_models, model_quant, errors
+from modules.logger import log
+
+
+KNOWN_PREFIXES = ("model.diffusion_model.", "diffusion_model.")
+ADAPTER_PREFIX = "llm_adapter."
+COSMOS_1_MARKER = "net.blocks.block1.blocks.0.block.attn.to_q.0.weight"
+
+# Buffer keys that CosmosTransformer3DModel creates at __init__ time and do
+# not appear in trainer state dicts. Acceptable in the "missing" set.
+ACCEPTABLE_MISSING = ("rope.", "pos_embedder.", "learnable_pos_embed.")
+
+
+def load_custom_transformer(repo_id, local_file, diffusers_load_config, adapter_cls):
+    """Load a custom Anima transformer (and optional bundled adapter) from a safetensors file.
+
+    Returns ``(transformer, llm_adapter_or_none)``. If the file does not bundle
+    an adapter, the second element is ``None`` and the caller should fall back
+    to the base repo's adapter via ``AnimaLLMAdapter.from_pretrained``.
+    Raises on any hard failure (prefix mix, shape mismatch, missing configs).
+    """
+    t0 = time.time()
+
+    if not local_file.lower().endswith('.safetensors'):
+        raise ValueError(f'Load model: type=Anima custom transformer requires .safetensors, got "{local_file}"')
+
+    # from_config + load_state_dict does not consume load_args (device_map,
+    # torch_dtype, etc.); dtype is applied via explicit .to() below. Only
+    # quant_type is read from this call.
+    _, quant_args = model_quant.get_dit_args(
+        diffusers_load_config, module='Model', device_map=True, allow_quant=True,
+    )
+    quant_type = model_quant.get_quant_type(quant_args)
+
+    transformer_cfg = fetch_component_config(repo_id, 'transformer/config.json')
+    adapter_cfg = fetch_component_config(repo_id, 'llm_adapter/config.json')
+
+    state_dict = sd_models.read_state_dict(local_file, what='transformer')
+    state_dict = strip_prefix(state_dict)
+    transformer_sd, adapter_sd = partition_adapter(state_dict)
+    del state_dict
+
+    if COSMOS_1_MARKER in transformer_sd:
+        raise ValueError(f'Load model: type=Anima custom transformer has unsupported Cosmos 1.0 structure (file="{local_file}")')
+
+    log.info(f'Load model: type=Anima custom="{os.path.basename(local_file)}" transformer_keys={len(transformer_sd)} adapter_keys={len(adapter_sd)}')
+
+    transformer = build_transformer(transformer_sd, transformer_cfg, quant_args, quant_type)
+    del transformer_sd
+    devices.torch_gc()
+
+    if adapter_sd:
+        llm_adapter = build_adapter(adapter_sd, adapter_cfg, adapter_cls)
+    else:
+        log.info('Load model: type=Anima custom transformer has no bundled adapter, caller will load from base repo')
+        llm_adapter = None
+
+    sd_models.allow_post_quant = False  # transformer already quantized above
+    devices.torch_gc()
+    log.debug(f'Load model: type=Anima custom transformer time={time.time()-t0:.2f}')
+    return transformer, llm_adapter
+
+
+def fetch_component_config(repo_id, relative_path):
+    """Download and parse a component config.json from the base repo."""
+    try:
+        local = hf.hf_hub_download(repo_id, filename=relative_path, cache_dir=shared.opts.diffusers_dir)
+    except Exception as e:
+        raise RuntimeError(f'Load model: type=Anima failed to download {relative_path} from repo="{repo_id}": {e}') from e
+    return shared.readfile(local, as_type='dict')
+
+
+def strip_prefix(state_dict):
+    """Detect and uniformly strip the BFL-style prefix from all keys.
+
+    Supported prefixes (longest first, so ``model.diffusion_model.`` beats ``diffusion_model.``):
+    ``model.diffusion_model.``, ``diffusion_model.``, or no prefix. Raises
+    ValueError if some keys match the dominant prefix and others do not,
+    since mixed prefixes indicate a malformed file.
+    """
+    counts = {p: sum(1 for k in state_dict if k.startswith(p)) for p in KNOWN_PREFIXES}
+    total = len(state_dict)
+    dominant = max(counts, key=counts.get)
+    if counts[dominant] == 0:
+        log.debug('Load model: type=Anima custom transformer prefix=bare')
+        return state_dict
+    if counts[dominant] != total:
+        raise ValueError(
+            f'Load model: type=Anima custom transformer has mixed prefixes '
+            f'(total={total} {dominant}={counts[dominant]})'
+        )
+    log.debug(f'Load model: type=Anima custom transformer prefix="{dominant}"')
+    offset = len(dominant)
+    return {k[offset:]: v for k, v in state_dict.items()}
+
+
+def partition_adapter(state_dict):
+    """Split into (transformer_sd, adapter_sd) by the ``llm_adapter.`` prefix."""
+    transformer_sd = {}
+    adapter_sd = {}
+    for key, value in state_dict.items():
+        if key.startswith(ADAPTER_PREFIX):
+            adapter_sd[key[len(ADAPTER_PREFIX):]] = value
+        else:
+            transformer_sd[key] = value
+    return transformer_sd, adapter_sd
+
+
+def build_transformer(transformer_sd, transformer_cfg, quant_args, quant_type):
+    """Convert, instantiate, load, dtype-cast, quantize, and (if offloading) move to CPU."""
+    from diffusers.loaders.single_file_utils import convert_cosmos_transformer_checkpoint_to_diffusers
+    try:
+        converted = convert_cosmos_transformer_checkpoint_to_diffusers(transformer_sd)
+        transformer = diffusers.CosmosTransformer3DModel.from_config(transformer_cfg)
+        missing, unexpected = transformer.load_state_dict(converted, strict=False)
+        validate_state_dict_load('transformer', missing, unexpected)
+        del converted
+        devices.torch_gc()
+        transformer = transformer.to(dtype=devices.dtype)
+    except Exception as e:
+        log.error(f'Load model: type=Anima transformer load failed: {e}')
+        errors.display(e, 'Load')
+        raise
+
+    apply_quant(transformer, quant_type)
+
+    if shared.opts.diffusers_offload_mode != 'none':
+        sd_models.move_model(transformer, devices.cpu)
+
+    if not hasattr(transformer, 'quantization_config'):
+        if hasattr(transformer, 'config') and hasattr(transformer.config, 'quantization_config'):
+            transformer.quantization_config = transformer.config.quantization_config
+        elif (quant_type is not None) and (quant_args.get('quantization_config', None) is not None):
+            transformer.quantization_config = quant_args.get('quantization_config', None)
+    return transformer
+
+
+def build_adapter(adapter_sd, adapter_cfg, adapter_cls):
+    """Instantiate AnimaLLMAdapter from the base repo config and load bundled weights."""
+    try:
+        adapter = adapter_cls.from_config(adapter_cfg)
+        missing, unexpected = adapter.load_state_dict(adapter_sd, strict=False)
+        validate_state_dict_load('adapter', missing, unexpected)
+        adapter = adapter.to(dtype=devices.dtype)
+    except Exception as e:
+        log.error(f'Load model: type=Anima adapter load failed: {e}')
+        errors.display(e, 'Load')
+        raise
+    if shared.opts.diffusers_offload_mode != 'none':
+        sd_models.move_model(adapter, devices.cpu)
+    return adapter
+
+
+def validate_state_dict_load(component, missing, unexpected):
+    """Raise ValueError if load_state_dict produced unexpected keys or non-buffer missing keys."""
+    if unexpected:
+        sample = ', '.join(unexpected[:5])
+        raise ValueError(f'Load model: type=Anima {component} has {len(unexpected)} unexpected keys (sample: {sample})')
+    hard_missing = [k for k in missing if not any(k.startswith(p) for p in ACCEPTABLE_MISSING)]
+    if hard_missing:
+        sample = ', '.join(hard_missing[:5])
+        raise ValueError(f'Load model: type=Anima {component} missing {len(hard_missing)} required keys (sample: {sample})')
+    if missing:
+        log.debug(f'Load model: type=Anima {component} ignored {len(missing)} buffer-only missing keys')
+
+
+def apply_quant(transformer, quant_type):
+    """Apply SDNQ / layerwise quantization to the bare transformer.
+
+    SDNQ 'pre' and 'auto' would normally route through ``quantization_config``
+    at ``from_pretrained`` time; since we bypass that boundary, we call the
+    per-module quant path directly. SDNQ 'post' and ``layerwise_quantization``
+    go through ``do_post_load_quant`` as usual.
+    """
+    if quant_type == 'NVIDIAModelOptConfig':
+        log.warning('Load model: type=Anima quant=TRT not supported on custom transformer path, skipping')
+    elif quant_type == 'SDNQConfig':
+        if shared.opts.sdnq_quantize_mode == 'pre':
+            log.info('Load model: type=Anima quant=SDNQ pre-mode applied post-load on custom transformer path')
+        model_quant.sdnq_quantize_model(transformer, op='transformer')
+    # allow=False avoids double-applying SDNQ in auto mode (applied directly
+    # above); post mode fires regardless of allow, and layerwise always fires.
+    model_quant.do_post_load_quant(transformer, allow=False)

--- a/pipelines/anima/anima_transformer.py
+++ b/pipelines/anima/anima_transformer.py
@@ -19,6 +19,7 @@ Supported input formats (safetensors only; GGUF and .pth are rejected early):
 - Bare BFL keys: ``blocks.0.self_attn.q_proj.weight`` (e.g. ``rdbtAnima_v027``)
 - ``model.diffusion_model.`` prefix (e.g. ``animaika_v35``)
 - ``diffusion_model.`` prefix (ComfyUI-style export)
+- ``net.`` prefix (NVIDIA/Cosmos native export, e.g. ``animayume_v04``)
 
 Quantization: SDNQ (pre/post/auto) and ``layerwise_quantization`` are honored.
 SDNQ pre-mode is applied post-load here because this path bypasses
@@ -35,7 +36,7 @@ from modules import shared, devices, sd_models, model_quant, errors
 from modules.logger import log
 
 
-KNOWN_PREFIXES = ("model.diffusion_model.", "diffusion_model.")
+KNOWN_PREFIXES = ("model.diffusion_model.", "diffusion_model.", "net.")
 ADAPTER_PREFIX = "llm_adapter."
 COSMOS_1_MARKER = "net.blocks.block1.blocks.0.block.attn.to_q.0.weight"
 

--- a/pipelines/model_anima.py
+++ b/pipelines/model_anima.py
@@ -1,9 +1,10 @@
+import os
 import sys
 import importlib.util
 import transformers
 import diffusers
 import huggingface_hub as hf
-from modules import shared, devices, sd_models, model_quant, sd_hijack_te, sd_hijack_vae
+from modules import shared, devices, sd_models, model_quant, sd_hijack_te, sd_hijack_vae, errors
 from modules.logger import log
 from pipelines import generic
 
@@ -13,6 +14,45 @@ def _import_from_file(module_name, file_path):
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
+
+
+def resolve_custom_transformer_path():
+    """Return an absolute path if the user selected a transformer in the UNET
+    dropdown and the file is resolvable, else ``None``.
+    """
+    sel = shared.opts.sd_unet
+    if sel is None or sel in ('Default', 'None'):
+        return None
+    from modules import sd_unet
+    if sel not in list(sd_unet.unet_dict):
+        log.error(f'Load module: type=transformer file="{sel}" not found')
+        return None
+    path = sd_unet.unet_dict[sel]
+    if not os.path.exists(path):
+        log.error(f'Load module: type=transformer path="{path}" does not exist')
+        return None
+    return path
+
+
+def load_transformer_components(repo_id, diffusers_load_config, adapter_cls):
+    """Load (transformer, llm_adapter_or_none).
+
+    If the UNET dropdown points at a valid safetensors, route through the
+    custom-transformer helper, which also extracts the bundled adapter
+    weights. Otherwise fall back to ``generic.load_transformer`` and return
+    ``None`` for the adapter so the caller loads it from the base repo.
+    """
+    local_file = resolve_custom_transformer_path()
+    if local_file is not None:
+        from pipelines.anima import anima_transformer
+        try:
+            return anima_transformer.load_custom_transformer(repo_id, local_file, diffusers_load_config, adapter_cls)
+        except Exception as e:
+            log.error(f'Load model: type=Anima custom transformer="{local_file}": {e}')
+            errors.display(e, 'Load')
+            return None, None
+    transformer = generic.load_transformer(repo_id, cls_name=diffusers.CosmosTransformer3DModel, load_config=diffusers_load_config, subfolder="transformer")
+    return transformer, None
 
 
 def load_anima(checkpoint_info, diffusers_load_config=None):
@@ -41,23 +81,27 @@ def load_anima(checkpoint_info, diffusers_load_config=None):
     AnimaTextToImagePipeline = pipeline_mod.AnimaTextToImagePipeline
     AnimaLLMAdapter = adapter_mod.AnimaLLMAdapter
 
-    # load components
-    transformer = generic.load_transformer(repo_id, cls_name=diffusers.CosmosTransformer3DModel, load_config=diffusers_load_config, subfolder="transformer")
+    # UNET dropdown (shared.opts.sd_unet) may redirect the transformer to a
+    # community file that bundles both the transformer and the llm_adapter.
+    transformer, llm_adapter = load_transformer_components(repo_id, diffusers_load_config, AnimaLLMAdapter)
+    if transformer is None:
+        return None
     text_encoder = generic.load_text_encoder(repo_id, cls_name=transformers.Qwen3Model, load_config=diffusers_load_config, subfolder="text_encoder", allow_shared=False)
 
-    shared.state.begin('Load adapter')
-    try:
-        llm_adapter = AnimaLLMAdapter.from_pretrained(
-            repo_id,
-            subfolder="llm_adapter",
-            cache_dir=shared.opts.diffusers_dir,
-            torch_dtype=devices.dtype,
-        )
-    except Exception as e:
-        log.error(f'Load model: type=Anima adapter: {e}')
-        return None
-    finally:
-        shared.state.end()
+    if llm_adapter is None:
+        shared.state.begin('Load adapter')
+        try:
+            llm_adapter = AnimaLLMAdapter.from_pretrained(
+                repo_id,
+                subfolder="llm_adapter",
+                cache_dir=shared.opts.diffusers_dir,
+                torch_dtype=devices.dtype,
+            )
+        except Exception as e:
+            log.error(f'Load model: type=Anima adapter: {e}')
+            return None
+        finally:
+            shared.state.end()
 
     tokenizer = transformers.AutoTokenizer.from_pretrained(repo_id, subfolder="tokenizer", cache_dir=shared.opts.diffusers_dir)
     t5_tokenizer = transformers.AutoTokenizer.from_pretrained(repo_id, subfolder="t5_tokenizer", cache_dir=shared.opts.diffusers_dir)


### PR DESCRIPTION
## Description

Adds two features to Anima support:

1. Custom transformer loading via the UNET dropdown.
2. Native LoRA loading. Routes Anima LoRAs through the native loader spanning the transformer, `llm_adapter`, and Qwen3 text encoder, covering Kohya, BFL/AI-toolkit, and hybrid (BFL with `.alpha` plus Qwen3 text encoder branch) trainer formats.

## Notes

A bit of weirdness due to the llm adapter, so I'm going to elaborate more than usual for the LoRA native support I make.

- New package `pipelines/anima/` holding two helpers: `anima_transformer.py` for custom-transformer loading and `anima_lora.py` for the LoRA loader.
- `model_type` is split: `AnimaTextToImage*` now resolves to `'anima'` rather than overloading `'cosmos'`. Cascading edits to keep behavior intact: `'anima'` added to `flow_models` (`sd_samplers_common.py`), TAESD `supported` list, and the TAE WanVideo bucket in `sd_vae_taesd.py:77` (preview decode would otherwise warn `unsupported`). Three places in total, swept through the rest of the code, no other issues spotted.
- `lora_convert.assign_network_names_to_compvis_modules` extended with a new branch walking `pipe.llm_adapter` under the `lora_llm_adapter_` prefix. Guarded by `hasattr(sd_model, 'llm_adapter') and sd_model.llm_adapter is not None`, so non-Anima models are unaffected.
- `'llm_adapter'` added to `default_components` in `networks.py` (and the inline list in `network_deactivate`). The `getattr(sd_model, name, None)` check at `network_activate:32-33` keeps it inert for any model that does not expose the attribute.
- Native LoRA path bypasses `KeyConvert` entirely (matches `flux2_lora` and `zimage_lora`). The Cosmos 2.0 path rename is mirrored from `diffusers.loaders.single_file_utils.convert_cosmos_transformer_checkpoint_to_diffusers`'s `TRANSFORMER_KEYS_RENAME_DICT_COSMOS_2_0` table, transposed into flat (underscore) form so substring replace lands directly on `network_layer_mapping` keys without re-splitting on dots.
- Custom transformer path honors SDNQ (pre-mode auto-promoted to post since `from_pretrained` is bypassed).
- Model-loading-side change is limited to `lora_convert.py` (one new branch), `networks.py` (one entry in two lists), and the early dispatch branch in `lora_load.py`.

## Environment and Testing

Linux (WSL2, kernel 6.6), RTX 3090 24GB, CUDA 13.0, Python 3.13

Tested with multiple custom transformers and parsed through 50+ LoRA, so I should capture at least the most common types.